### PR TITLE
Updated default values to respect the sentry.db_instance option.

### DIFF
--- a/migrations/2012_08_15_001334_database_rules.php
+++ b/migrations/2012_08_15_001334_database_rules.php
@@ -38,9 +38,11 @@ class Sentry_Database_Rules
 		});
 
 		// Insert default values
-		DB::table(Config::get('sentry::sentry.table.rules'))
+		DB::connection(Config::get('sentry::sentry.db_instance'))
+			->table(Config::get('sentry::sentry.table.rules'))
 			->insert(array('rule' => 'superuser', 'description' => 'Access to Everything'));
-		DB::table(Config::get('sentry::sentry.table.rules'))
+		DB::connection(Config::get('sentry::sentry.db_instance'))
+			->table(Config::get('sentry::sentry.table.rules'))
 			->insert(array('rule' => 'is_admin', 'description' => 'Administrative Privileges'));
 	}
 


### PR DESCRIPTION
The rest of the Schema editing in the migration checks for the correct
db instance, but by default calling DB::table by itself will fall back
to the default table.

Setting the connection on those inserts fixes this bug.

Signed-off-by: Spencer Deinum spencerdeinum@gmail.com
