### PR TITLE
Update config/sentry.php

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -66,6 +66,17 @@ return array(
 		 * How long the cookie should last. (seconds)
 		 */
 		'expire' => 20160, // 2 weeks - minutes
+		
+		 /**
+                 * Domain name credentials are stored in
+                 */
+                'cookie_domain' => null,
+
+                /**
+                 * path name credentials are stored in
+                 */
+                'cookie_path' => '/',
+
 	),
 
 	/**


### PR DESCRIPTION
Give the users the options to set their domain cookies and path, instead of saving it automatic on the current domain.

Users had to login twice to the site under mydomain.com and www.mydomain.
