### PR TITLE
Allow for automatic login after password reset

### DIFF
--- a/sentry.php
+++ b/sentry.php
@@ -406,7 +406,7 @@ class Sentry
 	 *
 	 * @param   string  Login Column value
 	 * @param   string  Reset password code
-	 * @return  bool
+	 * @return  bool|int  If confirmed, user Id; else, false
 	 * @throws  SentryException
 	 */
 	public static function reset_password_confirm($login_column_value, $code, $decode = true)
@@ -446,7 +446,7 @@ class Sentry
 				'remember_me' => '',
 			), false);
 
-			return true;
+			return (int) $user->id;
 		}
 
 		return false;


### PR DESCRIPTION
The purpose of this change is to allow you to automatically log the user in via `Sentry::force_login($id)` immediately after the verification link is clicked and the hash is confirmed.

In order to do so, `reset_password_confirm()` must return the user id.

Here's an updated password reset flow that can now be performed:
1. User enters email address on "Forgot password" page
2. Email with reset link sent to user
3. User clicks link and reset hash is confirmed
4. User is automatically logged in and taken to "Update password" page

Because it still returns a non-null value on success, this change should not break any existing implementations (unless somebody is specifically checking for a boolean response, which the example code on the site does not).
