### PR TITLE
Incorrect namespace for CookieJar class.

### DIFF
--- a/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
+++ b/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
@@ -18,7 +18,7 @@
  * @link       http://cartalyst.com
  */
 
-use Illuminate\CookieJar;
+use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\Cookie;
 
 class IlluminateCookie implements CookieInterface {


### PR DESCRIPTION
Not sure when it was updated, but the CookieJar class in Laravel is under Illuminate\Cookie\CookieJar instead of Illuminate\CookieJar.

Fixes:

Catchable Fatal Error: Argument 1 passed to Cartalyst\Sentry\Cookies\IlluminateCookie::__construct() must be an instance of Illuminate\CookieJar, instance of Illuminate\Cookie\CookieJar given, called in /vendor/cartalyst/sentry/src/Cartalyst/Sentry/SentryServiceProvider.php on line 77 and defined in /vendor/cartalyst/sentry/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php line 54
