### PR TITLE
Namespace fix in registration docs

### DIFF
--- a/docs/users/register.md
+++ b/docs/users/register.md
@@ -30,11 +30,11 @@ Parameters                   | Type            | Default       | Description
 		// Send activation code to user to activate their account
 		...
 	}
-	catch (Cartalyst\Sentry\LoginRequiredException $e)
+	catch (Cartalyst\Sentry\Users\LoginRequiredException $e)
 	{
 		echo 'Login field required.';
 	}
-	catch (Cartalyst\Sentry\UserExistsException $e)
+	catch (Cartalyst\Sentry\Users\UserExistsException $e)
 	{
 		echo 'User already exists.';
 	}


### PR DESCRIPTION
The example was missing \User in the Exception handlers, which would mean the expected exceptions wouldn't be caught
