### PR TITLE
Fix for issue #60

### DIFF
--- a/src/Cartalyst/Sentry/Hashing/BcryptHasher.php
+++ b/src/Cartalyst/Sentry/Hashing/BcryptHasher.php
@@ -48,7 +48,7 @@ class BcryptHasher implements HasherInterface {
 		// Create salt
 		$salt = $this->createSalt();
 
-		return crypt($string, '$2a$'.$strength.'$'.$salt);
+		return crypt($string, '$2a$'.$strength.'$'.$salt.'$');
 	}
 
 	/**


### PR DESCRIPTION
According to php.net, the salts for blowfish-crypts should end with a $-sign.
That was missing. Adding this gave proper hashes.

This is a fix to issue #60! I hope it's enough as cryptography is not really my business :) 
