### PR TITLE
Tests for deleting users and groups

### DIFF
--- a/tests/EloquentGroupTest.php
+++ b/tests/EloquentGroupTest.php
@@ -253,4 +253,15 @@ class EloquentGroupTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, (string) $group);
 	}
 
+	public function testDeletingGroupDetachesAllUserRelationships()
+	{
+		$relationship = m::mock('StdClass');
+		$relationship->shouldReceive('detach')->once();
+
+		$group = m::mock('Cartalyst\Sentry\Groups\Eloquent\Group[users]');
+		$group->shouldReceive('users')->once()->andReturn($relationship);
+
+		$group->delete();
+	}
+
 }

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -509,4 +509,15 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, (string) $user);
 	}
 
+	public function testDeletingUserDetachesAllGroupRelationships()
+	{
+		$relationship = m::mock('StdClass');
+		$relationship->shouldReceive('detach')->once();
+
+		$user = m::mock('Cartalyst\Sentry\Users\Eloquent\User[groups]');
+		$user->shouldReceive('groups')->once()->andReturn($relationship);
+
+		$user->delete();
+	}
+
 }


### PR DESCRIPTION
@bencorlett, I know you said you'd write the tests for the pull request I submitted (Issue #65) - but I decided to give it a try myself.  It passes the unit test, but what I'm concerned with is how to test "return parent::delete()".  Since the delete method in Sentry is returning what it gets from parent::delete() I figured there should be an assert.  But the problem is during testing it seems that it will always return null - to me it just doesn't seem logical to always assert that it's null.  Let me know what you think.  Thanks.
