### PR TITLE
Throw a descriptive RuntimeException if password_hash() (>PHP5.5.0) doesn't exist

### DIFF
--- a/src/Cartalyst/Sentry/Hashing/NativeHasher.php
+++ b/src/Cartalyst/Sentry/Hashing/NativeHasher.php
@@ -31,6 +31,11 @@ class NativeHasher implements HasherInterface {
 		// Usually caused by an old PHP environment, see
 		// https://github.com/cartalyst/sentry/issues/98#issuecomment-12974603
 		// and https://github.com/ircmaxell/password_compat/issues/10
+		if (! function_exists('password_hash'))
+		{
+			throw new \RuntimeException('The function password_hash() does not exist, your PHP environment is probably incompatible. Try running [vendor/ircmaxell/password-compat/version-test.php] to check compatibility or use an alternative hashing strategy.');	
+		}
+
 		if (($hash = password_hash($string, PASSWORD_DEFAULT)) === false)
 		{
 			throw new \RuntimeException('Error generating hash from string, your PHP environment is probably incompatible. Try running [vendor/ircmaxell/password-compat/version-test.php] to check compatibility or use an alternative hashing strategy.');


### PR DESCRIPTION
Some people might not be aware of the fact that password_hash() is only available after PHP5.5.0 and might get confused that they get function not found exceptions while they aren't doing anything wrong. A descriptive RuntimeException is to the rescue!
