### PR TITLE
Add wildcard "*" support in permission settings.

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -576,6 +576,8 @@ class User extends Model implements UserInterface {
 
 			else
 			{
+				$matched = false;
+
 				foreach ($mergedPermissions as $mergedPermission => $value)
 				{
 					// This time check if the mergedPermission ends in wildcard "*" symbol.

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -599,7 +599,8 @@ class User extends Model implements UserInterface {
 					// we match that permissions explicitly exist.
 					elseif ($permission == $mergedPermission and $mergedPermissions[$permission] == 1)
 					{
-						$matches = true;
+						$matched = true;
+						break;
 					}
 				}
 			}

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -574,13 +574,33 @@ class User extends Model implements UserInterface {
 				}
 			}
 
-			// Otherwise, we'll fallback to standard permissions checking where
-			// we match that permissions explicitly exist.
 			else
 			{
-				if ( ! array_key_exists($permission, $mergedPermissions) or $mergedPermissions[$permission] != 1)
+				foreach ($mergedPermissions as $mergedPermission => $value)
 				{
-					$matched = false;
+					// This time check if the mergedPermission ends in wildcard "*" symbol.
+					if ((strlen($mergedPermission) > 1) and ends_with($mergedPermission, '*'))
+					{
+						$matched = false;
+
+						// Strip the '*' off the end of the permission.
+						$checkMergedPermission = substr($mergedPermission, 0, -1);
+
+						// We will make sure that the merged permission does not
+						// exactly match our permission, but starts wtih it.
+						if ($checkMergedPermission != $permission and starts_with($permission, $checkMergedPermission) and $value == 1)
+						{
+							$matched = true;
+							break;
+						}
+					}
+
+					// Otherwise, we'll fallback to standard permissions checking where
+					// we match that permissions explicitly exist.
+					elseif ($permission == $mergedPermission and $mergedPermissions[$permission] == 1)
+					{
+						$matches = true;
+					}
 				}
 			}
 

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -202,7 +202,7 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Feature test for https://github.com/cartalyst/sentry/issues/123
 	 */
-	public function testWildcardPermissions()
+	public function testWildcardPermissionsCheck()
 	{
 		$user = m::mock('Cartalyst\Sentry\Users\Eloquent\User[isSuperUser,getMergedPermissions]');
 		$user->shouldReceive('isSuperUser')->atLeast(1)->andReturn(false);
@@ -214,6 +214,23 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($user->hasAccess('users'));
 		$this->assertTrue($user->hasAccess('users.*'));
 	}
+
+	/**
+	 * Feature test for https://github.com/cartalyst/sentry/pull/131
+	 */
+	public function testWildcardPermissionsSetting()
+	{
+		$user = m::mock('Cartalyst\Sentry\Users\Eloquent\User[isSuperUser,getMergedPermissions]');
+		$user->shouldReceive('isSuperUser')->atLeast(1)->andReturn(false);
+		$user->shouldReceive('getMergedPermissions')->atLeast(1)->andReturn(array(
+			'users.*' => 1,
+		));
+
+		$this->assertFalse($user->hasAccess('users'));
+		$this->assertTrue($user->hasAccess('users.edit'));
+		$this->assertTrue($user->hasAccess('users.delete'));
+	}
+
 
 	public function testAnyPermissions()
 	{


### PR DESCRIPTION
Currently, wildcard "*" is only allowed in permission checks but not in the permission settings. This allows permission setting to use wildcards also. If a permission setting is defined as `admin.posts. *` then the check `hasAccess('admin.posts.edit')` will return true.

This is especially helpful in L4 where it is possible to automatically do a check on every `controller.action` using a generic filter and no explicit checking anywhere else.

The code is symetrical to the current code wildcard "*" support for permission checks.
