### PR TITLE
Clarified $suspensionTime definition

### DIFF
--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
@@ -297,10 +297,10 @@ class Throttle extends Model implements ThrottleInterface {
 	 */
 	public function removeSuspensionIfAllowed()
 	{
-		$suspended   = clone($this->suspended_at);
+		$suspended      = clone($this->suspended_at);
 		$suspensionTime = static::$suspensionTime;
-		$unsuspendAt = $suspended->modify("+{$suspensionTime} minutes");
-		$now         = new DateTime;
+		$unsuspendAt    = $suspended->modify("+{$suspensionTime} minutes");
+		$now            = new DateTime;
 
 		if ($unsuspendAt <= $now)
 		{


### PR DESCRIPTION
Perhaps this was only me, but +{static::$suspensionTime} was triggering an Undefined variable error.  This changes that line to match the method used in clearLoginAttemptsIfAllowed(). 
