### PR TITLE
Removed the "=" sign in the where clause

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
@@ -129,7 +129,7 @@ class Provider implements ProviderInterface {
 			}
 			else
 			{
-				$query = $query->where($credential, '=', $value);
+				$query = $query->where($credential, $value);
 			}
 		}
 


### PR DESCRIPTION
The "=" is not needed as it is default behavior.

Removing it gave me the abillity to use Sentry in conjunction with LMongo (https://github.com/navruzm/lmongo)
