### PR TITLE
Adds single quotes to service provider

### DIFF
--- a/docs/installation/laravel-4.md
+++ b/docs/installation/laravel-4.md
@@ -9,7 +9,7 @@ Add `"cartalyst/sentry": "2.0.*"` to the `require` attribute of your `composer.j
 
 ##### Step 2
 
-Add `Cartalyst\Sentry\SentryServiceProvider` to the list of service providers in `app/config/app.php`
+Add `'Cartalyst\Sentry\SentryServiceProvider'` to the list of service providers in `app/config/app.php`
 
 ##### Step 3  *(optional)*
 


### PR DESCRIPTION
Adds single quotes around the ServiceProvider example. For consistency with the other examples provided and for those who just copy/paste, don't have to worry about forgetting them.
