### PR TITLE
salt for bcrypt should be 22 characters

### DIFF
--- a/src/Cartalyst/Sentry/Hashing/BcryptHasher.php
+++ b/src/Cartalyst/Sentry/Hashing/BcryptHasher.php
@@ -32,7 +32,7 @@ class BcryptHasher implements HasherInterface {
 	 *
 	 * @var int
 	 */
-	public $saltLength = 16;
+	public $saltLength = 22;
 
 	/**
 	 * Hash string.


### PR DESCRIPTION
According to the documentation @ http://php.net/manual/en/function.crypt.php bcrypt salts should be 22 characters in length; the default is set to 16 in BcryptHasher so should be changed.
