### PR TITLE
Fixing superuser permission checking

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -248,14 +248,7 @@ class User extends Model implements UserInterface {
 	 */
 	public function isSuperUser()
 	{
-		$permissions = $this->getPermissions();
-
-		if ( ! array_key_exists('superuser', $permissions))
-		{
-			return false;
-		}
-
-		return $permissions['superuser'] == 1;
+		return $this->hasPermission('superuser');
 	}
 
 	/**


### PR DESCRIPTION
Fixed issue where isSuperUser() would return false if the user is a superuser by a group permission. It now checks both the user's and the user's groups' permissions.
