### PR TITLE
Fix typo in ConnectionResolver

### DIFF
--- a/src/Cartalyst/Sentry/Facades/ConnectionResolver.php
+++ b/src/Cartalyst/Sentry/Facades/ConnectionResolver.php
@@ -132,7 +132,7 @@ class ConnectionResolver implements ConnectionResolverInterface {
 					break;
 
 				case 'sqlite':
-					$queryGrammar = 'Illuminate\Database\Query\Grammars\SQLiteGrammer';
+					$queryGrammar = 'Illuminate\Database\Query\Grammars\SQLiteGrammar';
 					break;
 
 				default:


### PR DESCRIPTION
The switch in ConnectionResolver::getConnection determines what grammar class to use, but there's a typo in one of the class names (SQLiteGrammer --> SQLiteGrammar).
