### PR TITLE
Cache the user's groups so that permission checks don't result in multiple db calls

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -109,7 +109,14 @@ class User extends Model implements UserInterface {
 	 * @var null
 	 */
 	protected static $userGroups = null;
-
+	
+	/**
+	 * The user's merged permissions
+	 *
+	 * @var null
+	 */
+	protected static $mergedPermissions = null;
+	
 	/**
 	 * Returns the user's ID.
 	 *
@@ -538,16 +545,19 @@ class User extends Model implements UserInterface {
 	 */
 	public function getMergedPermissions()
 	{
-		$permissions = array();
-
-		foreach ($this->getGroups() as $group)
+		if (static::$mergedPermissions === null)
 		{
-			$permissions = array_merge($permissions, $group->getPermissions());
+			$permissions = array();
+
+			foreach ($this->getGroups() as $group)
+			{
+				$permissions = array_merge($permissions, $group->getPermissions());
+			}
+
+			static::$mergedPermissions = array_merge($permissions, $this->getPermissions());
 		}
 
-		$permissions = array_merge($permissions, $this->getPermissions());
-
-		return $permissions;
+		return static::$mergedPermissions;
 	}
 
 	/**


### PR DESCRIPTION
Reference #191
