### PR TITLE
Break cache of user groups and permissions once a group is added/removed to that user

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -489,6 +489,8 @@ class User extends Model implements UserInterface {
 	{
 		if ( ! $this->inGroup($group))
 		{
+			$this->userGroups = null;
+			$this->mergedPermissions = null;
 			$this->groups()->attach($group);
 		}
 
@@ -505,6 +507,8 @@ class User extends Model implements UserInterface {
 	{
 		if ($this->inGroup($group))
 		{
+			$this->userGroups = null;
+			$this->mergedPermissions = null;
 			$this->groups()->detach($group);
 		}
 


### PR DESCRIPTION
As an example, if you do `$user->addGroup($group);` and then `$user->getMergedPermissions();`, you won't get the permissions changed by that `->addGroup` because those properties are still cached. This change breaks that cache when a group is added or removed.
