### PR TITLE
Removing ipAddress lookup option from throttle provider

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -193,7 +193,7 @@ class Sentry {
 		// to authenticate them
 		if ($throttlingEnabled = $this->throttleProvider->isEnabled())
 		{
-			if ($throttle = $this->throttleProvider->findByUserLogin($credentials[$loginName], $this->ipAddress))
+			if ($throttle = $this->throttleProvider->findByUserLogin($credentials[$loginName]))
 			{
 				$throttle->check();
 			}

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
@@ -66,19 +66,13 @@ class Provider implements ProviderInterface {
 	 * Finds a throttler by the given user ID.
 	 *
 	 * @param  mixed   $id
-	 * @param  string  $ipAddress
 	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserId($id, $ipAddress = null)
+	public function findByUserId($id)
 	{
 		$user  = $this->userProvider->findById($id);
 		$model = $this->createModel();
 		$query = $model->where('user_id', '=', ($userId = $user->getId()));
-
-		if ($ipAddress)
-		{
-			$query->where('ip_address', '=', $ipAddress);
-		}
 
 		if ( ! $throttle = $query->first())
 		{
@@ -95,20 +89,14 @@ class Provider implements ProviderInterface {
 	 * Finds a throttling interface by the given user login.
 	 *
 	 * @param  string  $login
-	 * @param  string  $ipAddress
 	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserLogin($login, $ipAddress = null)
+	public function findByUserLogin($login)
 	{
 		$user  = $this->userProvider->findByLogin($login);
 		$model = $this->createModel();
 		$query = $model->where('user_id', '=', ($userId = $user->getId()));
-
-		if ($ipAddress)
-		{
-			$query->where('ip_address', '=', $ipAddress);
-		}
-
+		
 		if ( ! $throttle = $query->first())
 		{
 			$throttle = $this->createModel();

--- a/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
+++ b/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
@@ -24,19 +24,17 @@ interface ProviderInterface {
 	 * Finds a throttler by the given user ID.
 	 *
 	 * @param  mixed   $id
-	 * @param  string  $ipAddress
 	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserId($id, $ipAddress = null);
+	public function findByUserId($id);
 
 	/**
 	 * Finds a throttling interface by the given user login.
 	 *
 	 * @param  string  $login
-	 * @param  string  $ipAddress
 	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserLogin($login, $ipAddress = null);
+	public function findByUserLogin($login);
 
 	/**
 	 * Enable throttling.

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -161,7 +161,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$emptyUser->shouldReceive('getLoginName')->once()->andReturn('email');
 
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
-		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com', '0.0.0.0')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
+		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
 
 		$throttle->shouldReceive('check')->once()->andThrow(new UserBannedException);
 
@@ -182,7 +182,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$emptyUser->shouldReceive('getLoginName')->once()->andReturn('email');
 
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
-		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com', '0.0.0.0')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
+		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
 
 		$throttle->shouldReceive('check')->once()->andThrow(new UserSuspendedException);
 
@@ -203,7 +203,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$emptyUser->shouldReceive('getLoginName')->once()->andReturn('email');
 
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
-		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com', '0.0.0.0')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
+		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
 
 		$throttle->shouldReceive('check')->once();
 
@@ -270,7 +270,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$emptyUser->shouldReceive('getLoginName')->once()->andReturn('email');
 
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
-		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com', '0.0.0.0')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
+		$this->throttleProvider->shouldReceive('findByUserLogin')->with('foo@bar.com')->once()->andReturn($throttle = m::mock('Cartalyst\Sentry\Throttling\ThrottleInterface'));
 
 		$throttle->shouldReceive('check')->once();
 


### PR DESCRIPTION
It currently creates a loop hole in logging in where a banned user can successfully login from another IP.  Since the $throttle->check() call is what ACTUALLY verifies if a user is suspended or banned, lets let that class be responsible for dealing with IP addresses.  The throttle provider should purely return throttle instances given a user's unique key.

This is what @max-online suggested in #159.
