### PR TITLE
Add function User->inGroupNamed($groupName)

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -505,6 +505,25 @@ class User extends Model implements UserInterface {
 	}
 
 	/**
+	 * See if the user is in the given group.
+	 *
+	 * @param  string  $groupName
+	 * @return bool
+	 */
+	public function inGroupNamed($groupName)
+	{
+		foreach ($this->getGroups() as $_group)
+		{
+			if ($_group->getName() == $groupName)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns an array of merged permissions for each
 	 * group the user is in.
 	 *

--- a/src/Cartalyst/Sentry/Users/UserInterface.php
+++ b/src/Cartalyst/Sentry/Users/UserInterface.php
@@ -206,6 +206,14 @@ interface UserInterface {
 	public function inGroup(GroupInterface $group);
 
 	/**
+	 * See if the user is in the given group.
+	 *
+	 * @param  string  $groupName
+	 * @return bool
+	 */
+	public function inGroupNamed($groupName);
+
+	/**
 	 * Returns an array of merged permissions for each
 	 * group the user is in.
 	 *


### PR DESCRIPTION
I've gotten really tired of writing 

```
$employeeGroup = Sentry::getGroupProvider()->findByName('Employee');
if ( $user->inGroup($employeeGroup)) {
...
```

Adding one little function lets me do this:

```
if ( $user->inGroupNamed('Employee)) {
...
```

Not only is it (I think) easier to read, it saves a DB call that we don't really need.
