### PR TITLE
Adding convenience methods to Sentry to hide Group/User/Throttle Providers

### DIFF
--- a/docs/authentication/login.md
+++ b/docs/authentication/login.md
@@ -36,7 +36,7 @@ When the provided user is banned, this exception will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Log the user in
 		Sentry::login($user, false);

--- a/docs/groups/create.md
+++ b/docs/groups/create.md
@@ -23,7 +23,7 @@ exists on your database.
 	try
 	{
 		// Create the group
-		$group = Sentry::getGroupProvider()->create(array(
+		$group = Sentry::createGroup(array(
 			'name'        => 'Users',
 			'permissions' => array(
 				'admin' => 1,

--- a/docs/groups/delete.md
+++ b/docs/groups/delete.md
@@ -17,7 +17,7 @@ If the provided group was not found, this exception will be thrown.
 	try
 	{
 		// Find the group using the group id
-		$group = Sentry::getGroupProvider()->findById(1);
+		$group = Sentry::findGroupById(1);
 
 		// Delete the group
 		if ($group->delete())

--- a/docs/groups/find.md
+++ b/docs/groups/find.md
@@ -18,7 +18,7 @@ This will return all the groups.
 
 ##### Example
 
-	$groups = Sentry::getGroupProvider()->findAll();
+	$groups = Sentry::findAllGroups();
 
 ----------
 
@@ -30,7 +30,7 @@ Find a group by it's ID.
 
 	try
 	{
-		$group = Sentry::getGroupProvider()->findById(1);
+		$group = Sentry::findGroupById(1);
 	}
 	catch (Cartalyst\Sentry\Groups\GroupNotFoundException $e)
 	{
@@ -47,7 +47,7 @@ Find a group by it's name.
 
 	try
 	{
-		$group = Sentry::getGroupProvider()->findByName('admin');
+		$group = Sentry::findGroupByName('admin');
 	}
 	catch (Cartalyst\Sentry\Groups\GroupNotFoundException $e)
 	{

--- a/docs/groups/helpers.md
+++ b/docs/groups/helpers.md
@@ -11,7 +11,7 @@ Returns the permissions of a group.
 	try
 	{
 		// Find the group using the group id
-		$group = Sentry::getGroupProvider()->findById(1);
+		$group = Sentry::findGroupById(1);
 
 		// Get the group permissions
 		$groupPermissions = $group->getPermissions();

--- a/docs/groups/update.md
+++ b/docs/groups/update.md
@@ -26,7 +26,7 @@ If the provided group was not found, this exception will be thrown.
 	try
 	{
 		// Find the group using the group id
-		$group = Sentry::getGroupProvider()->findById(1);
+		$group = Sentry::findGroupById(1);
 
 		// Update the group details
 		$group->name = 'Users';

--- a/docs/installation/composer.md
+++ b/docs/installation/composer.md
@@ -25,7 +25,7 @@ Example usage
 	// Done!
 
 	// Create our first user!
-	$user = Sentry::getUserProvider()->create(array(
+	$user = Sentry::createUser(array(
 		'email'    => 'testing@test.com',
 		'password' => 'test',
 		'permissions' => array(

--- a/docs/throttling/find.md
+++ b/docs/throttling/find.md
@@ -19,7 +19,7 @@ a throttle object.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{
@@ -37,7 +37,7 @@ retrieve a throttle object.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserLogin('john.doe@example.com');
+		$throttle = Sentry::findThrottlerByUserLogin('john.doe@example.com');
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{

--- a/docs/throttling/user-throttling.md
+++ b/docs/throttling/user-throttling.md
@@ -29,7 +29,7 @@ Bans the user associated with the throttle.
 	try
 	{
 		// Find the user using the user id
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		// Ban the user
 		$throttle->ban();
@@ -50,7 +50,7 @@ Unbans the user associated with the throttle.
 	try
 	{
 		// Find the user using the user id
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		// Unban the user
 		$throttle->unBan();
@@ -71,7 +71,7 @@ Checks to see if the user is banned.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		if($banned = $throttle->isBanned())
 		{
@@ -99,7 +99,7 @@ setSuspensionTime($minutes).
 	try
 	{
 		// Find the user using the user id
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		// Suspend the user
 		$throttle->suspend();
@@ -121,7 +121,7 @@ login if they were suspended.
 	try
 	{
 		// Find the user using the user id
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		// Unsuspend the user
 		$throttle->unsuspend();
@@ -141,7 +141,7 @@ Checks to see if the user is suspended.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		if($suspended = $throttle->isSuspended())
 		{
@@ -167,7 +167,7 @@ Sets the length of the suspension.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$throttle->setSuspensionTime(10);
 	}
@@ -186,7 +186,7 @@ Retrieves the length of the suspension time set by the throttling driver.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$suspensionTime = $throttle->getSuspensionTime();
 	}
@@ -207,7 +207,7 @@ Adds an attempt to the throttle object.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$throttle->addLoginAttempt();
 	}
@@ -229,7 +229,7 @@ attempts will be reset to 0.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$attempts = $throttle->getLoginAttempts();
 	}
@@ -248,7 +248,7 @@ Clears all login attempts, it also unsuspends them. This does not unban a login.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$throttle->clearLoginAttempts();
 	}
@@ -267,7 +267,7 @@ Checks the login throttle status and throws a number of Exceptions upon failure.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		if ($throttle->check())
 		{
@@ -299,7 +299,7 @@ Sets the number of attempts allowed before suspension.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$throttle->setAttemptLimit(3);
 	}
@@ -318,7 +318,7 @@ Retrieves the number of attempts allowed by the throttle object.
 
 	try
 	{
-		$throttle = Sentry::getThrottleProvider()->findByUserId(1);
+		$throttle = Sentry::findThrottlerByUserId(1);
 
 		$attemptLimit = $throttle->getAttemptLimit();
 	}

--- a/docs/users/activate.md
+++ b/docs/users/activate.md
@@ -27,7 +27,7 @@ If the provided user was not found, this exception will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Attempt to activate the user
 		if ($user->attemptActivation('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb'))

--- a/docs/users/create.md
+++ b/docs/users/create.md
@@ -39,13 +39,13 @@ already registerd on your database, you can't use this email for this user.
 	try
 	{
 		// Create the user
-		$user = Sentry::getUserProvider()->create(array(
+		$user = Sentry::createUser(array(
 			'email'    => 'john.doe@example.com',
 			'password' => 'test',
 		));
 
 		// Find the group using the group id
-		$adminGroup = Sentry::getGroupProvider()->findById(1);
+		$adminGroup = Sentry::findGroupById(1);
 
 		// Assign the group to the user
 		$user->addGroup($adminGroup);
@@ -81,7 +81,7 @@ will be thrown.
 	try
 	{
 		// Create the user
-		$user = Sentry::getUserProvider()->create(array(
+		$user = Sentry::createUser(array(
 			'email'       => 'john.doe@example.com',
 			'password'    => 'test',
 			'permissions' => array(

--- a/docs/users/delete.md
+++ b/docs/users/delete.md
@@ -17,7 +17,7 @@ If the provided user was not found, this exception will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Delete the user
 		if ($user->delete())

--- a/docs/users/find.md
+++ b/docs/users/find.md
@@ -40,7 +40,7 @@ This will return all the users.
 
 ##### Example
 
-	$users = Sentry::getUserProvider()->findAll();
+	$users = Sentry::findAllUsers();
 
 ----------
 
@@ -51,7 +51,7 @@ Finds all users with access to a permission(s).
 #### Example
 
 	// Feel free to pass a string for just one permission instead
-	$users = Sentry::getUserProvider()->findAllWithAccess(array('admin', 'other'));
+	$users = Sentry::findAllUsersWithAccess(array('admin', 'other'));
 
 ----------
 
@@ -61,7 +61,7 @@ Finds all users assigned to a group(s).
 
 #### Example
 
-	$users = Sentry::getUserProvider()->findAllInGroup(array('administrator', 'users'));
+	$users = Sentry::findAllUsersInGroup(array('administrator', 'users'));
 
 ----------
 
@@ -73,7 +73,7 @@ Find a user by an array of credentials, which must include the login column. Has
 
 	try
 	{
-		$user = Sentry::getUserProvider()->findByCredentials(array(
+		$user = Sentry::findUserByCredentials(array(
 			'email'      => 'john.doe@example.com',
 			'password'   => 'test',
 			'first_name' => 'John',
@@ -94,7 +94,7 @@ Find a user by their ID.
 
 	try
 	{
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{
@@ -111,7 +111,7 @@ Find a user by their login ID.
 
 	try
 	{
-		$user = Sentry::getUserProvider()->findByLogin('john.doe@example.com');
+		$user = Sentry::findUserByLogin('john.doe@example.com');
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{
@@ -128,7 +128,7 @@ Find a user by their registration activation code.
 
 	try
 	{
-		$user = Sentry::getUserProvider()->findByActivationCode('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb');
+		$user = Sentry::findUserByActivationCode('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb');
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{
@@ -145,7 +145,7 @@ Find a user by their reset password code.
 
 	try
 	{
-		$user = Sentry::getUserProvider()->findByResetPasswordCode('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb');
+		$user = Sentry::findUserByResetPasswordCode('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb');
 	}
 	catch (Cartalyst\Sentry\Users\UserNotFoundException $e)
 	{

--- a/docs/users/helpers.md
+++ b/docs/users/helpers.md
@@ -11,7 +11,7 @@ Checks if the provided password matches the user's current password.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		if($user->checkPassword('mypassword'))
 		{
@@ -38,7 +38,7 @@ Returns the user groups.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserByID(1);
 
 		// Get the user groups
 		$groups = $user->getGroups();
@@ -59,7 +59,7 @@ Returns the user permissions.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserByID(1);
 
 		// Get the user permissions
 		$permissions = $user->getPermissions();
@@ -86,7 +86,7 @@ regardless of the user permissions and group permissions.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserByID(1);
 
 		// Check if the user has the 'admin' permission. Also,
 		// multiple permissions may be used by passing an array
@@ -115,7 +115,7 @@ Checks if a user is activated.
 	try
 	{
 		// Find the user
-		$user = Sentry::getUserProvider()->findByLogin('jonh.doe@example.com');
+		$user = Sentry::findUserByLogin('jonh.doe@example.com');
 
 		// Check if the user is activated or not
 		if ($user->isActivated())
@@ -143,7 +143,7 @@ Returns if the user is a super user, it means, that has access to everything reg
 	try
 	{
 		// Find the user
-		$user = Sentry::getUserProvider()->findByLogin('jonh.doe@example.com');
+		$user = Sentry::findUserByLogin('jonh.doe@example.com');
 
 		// Check if this user is a super user
 		if ($user->isSuperUser())
@@ -171,10 +171,10 @@ Checks if a user is in a certain group.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserByID(1);
 
 		// Find the Administrator group
-		$admin = Sentry::getGroupProvider()->findByName('Administrator');
+		$admin = Sentry::findGroupByName('Administrator');
 
 		// Check if the user is in the administrator group
 		if ($user->inGroup($admin))

--- a/docs/users/reset-password.md
+++ b/docs/users/reset-password.md
@@ -22,7 +22,7 @@ The first step is to get a password reset code, to do this we use the
 	try
 	{
 		// Find the user using the user email address
-		$user = Sentry::getUserProvider()->findByLogin('john.doe@example.com');
+		$user = Sentry::findUserByLogin('john.doe@example.com');
 
 		// Get the password reset code
 		$resetCode = $user->getResetPasswordCode();
@@ -46,7 +46,7 @@ All the logic part on how you pass the reset password code is all up to you.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Check if the reset password code is valid
 		if ($user->checkResetPasswordCode('8f1Z7wA4uVt7VemBpGSfaoI9mcjdEwtK8elCnQOb'))

--- a/docs/users/update.md
+++ b/docs/users/update.md
@@ -33,7 +33,7 @@ If the provided user was not found, this exception will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Update the user details
 		$user->email = 'john.doe@example.com';
@@ -69,10 +69,10 @@ Exception `Cartalyst\Sentry\Users\UserExistsException` will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Find the group using the group id
-		$adminGroup = Sentry::getGroupProvider()->findById(1);
+		$adminGroup = Sentry::findGroupById(1);
 
 		// Assign the group to the user
 		if ($user->addGroup($adminGroup))
@@ -105,10 +105,10 @@ will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Find the group using the group id
-		$adminGroup = Sentry::getGroupProvider()->findById(1);
+		$adminGroup = Sentry::findGroupById(1);
 
 		// Assign the group to the user
 		if ($user->removeGroup($adminGroup))
@@ -141,10 +141,10 @@ will be thrown.
 	try
 	{
 		// Find the user using the user id
-		$user = Sentry::getUserProvider()->findById(1);
+		$user = Sentry::findUserById(1);
 
 		// Find the group using the group id
-		$adminGroup = Sentry::getGroupProvider()->findById(1);
+		$adminGroup = Sentry::findGroupById(1);
 
 		// Assign the group to the user
 		if ($user->addGroup($adminGroup))

--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -499,6 +499,205 @@ class Sentry {
 		return $this->ipAddress;
 	}
 
+    /**
+     * Find the group by ID.
+     *
+     * @param  int  $id
+     * @return Cartalyst\Sentry\GroupInterface  $group
+     * @throws Cartalyst\Sentry\GroupNotFoundException
+     */
+    public function findGroupById($id)
+    {
+        return $this->groupProvider->findById($id);
+    }
+
+    /**
+     * Find the group by name.
+     *
+     * @param  string  $name
+     * @return Cartalyst\Sentry\GroupInterface  $group
+     * @throws Cartalyst\Sentry\GroupNotFoundException
+     */
+    public function findGroupByName($name)
+    {
+        return $this->groupProvider->findByName($name);
+    }
+
+    /**
+     * Returns all groups.
+     *
+     * @return array  $groups
+     */
+    public function findAllGroups()
+    {
+        return $this->groupProvider->findAll();
+    }
+
+    /**
+     * Creates a group.
+     *
+     * @param  array  $attributes
+     * @return Cartalyst\Sentry\Groups\GroupInterface
+     */
+    public function createGroup(array $attributes)
+    {
+        return $this->groupProvider->create($attributes);
+    }
+
+
+    /**
+     * Finds a user by the given user ID.
+     *
+     * @param  mixed  $id
+     * @return Cartalyst\Sentry\Users\UserInterface
+     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     */
+    public function findUserById($id)
+    {
+        return $this->userProvider->findById($id);
+    }
+
+    /**
+     * Finds a user by the login value.
+     *
+     * @param  string  $login
+     * @return Cartalyst\Sentry\Users\UserInterface
+     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     */
+    public function findUserByLogin($login)
+    {
+        return $this->userProvider->findByLogin($login);
+    }
+
+    /**
+     * Finds a user by the given credentials.
+     *
+     * @param  array  $credentials
+     * @return Cartalyst\Sentry\Users\UserInterface
+     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     */
+    public function findUserByCredentials(array $credentials){
+        return $this->userProvider->findByCredentials($credentials);
+    }
+
+    /**
+     * Finds a user by the given activation code.
+     *
+     * @param  string  $code
+     * @return Cartalyst\Sentry\Users\UserInterface
+     * @throws RuntimeException
+     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     */
+    public function findUserByActivationCode($code)
+    {
+        return $this->userProvider->findByActivationCode($code);
+    }
+
+    /**
+     * Finds a user by the given reset password code.
+     *
+     * @param  string  $code
+     * @return Cartalyst\Sentry\Users\UserInterface
+     * @throws RuntimeException
+     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     */
+    public function findUserByResetPasswordCode($code)
+    {
+        return $this->userProvider->findByResetPasswordCode($code);
+    }
+
+    /**
+     * Returns an all users.
+     *
+     * @return array
+     */
+    public function findAllUsers()
+    {
+        return $this->userProvider->findAll();
+    }
+
+    /**
+     * Returns all users who belong to
+     * a group.
+     *
+     * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+     * @return array
+     */
+    public function findAllUsersInGroup($group)
+    {
+        return $this->userProvider->findAllInGroup($group);
+    }
+
+    /**
+     * Returns all users with access to
+     * a permission(s).
+     *
+     * @param  string|array  $permissions
+     * @return array
+     */
+    public function findAllUsersWithAccess($permissions)
+    {
+        return $this->userProvider->findAllWithAccess($permissions);
+    }
+
+    /**
+     * Returns all users with access to
+     * any given permission(s).
+     *
+     * @param  array  $permissions
+     * @return array
+     */
+    public function findAllUsersWithAnyAccess(array $permissions)
+    {
+        return $this->userProvider->findAllWithAnyAccess($permissions);
+    }
+
+    /**
+     * Creates a user.
+     *
+     * @param  array  $credentials
+     * @return Cartalyst\Sentry\Users\UserInterface
+     */
+    public function createUser(array $credentials)
+    {
+        return $this->userProvider->create($credentials);
+    }
+
+    /**
+     * Returns an empty user object.
+     *
+     * @return Cartalyst\Sentry\Users\UserInterface
+     */
+    public function getEmptyUser()
+    {
+        return $this->userProvider->getEmptyUser();
+    }
+
+    /**
+     * Finds a throttler by the given user ID.
+     *
+     * @param  mixed   $id
+     * @param  string  $ipAddress
+     * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+     */
+    public function findThrottlerByUserId($id, $ipAddress = null)
+    {
+        return $this->throttleProvider->findByUserId($id,$ipAddress);
+    }
+
+    /**
+     * Finds a throttling interface by the given user login.
+     *
+     * @param  string  $login
+     * @param  string  $ipAddress
+     * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+     */
+    public function findThrottlerByUserLogin($login, $ipAddress = null)
+    {
+        return $this->throttleProvider->findByUserLogin($login,$ipAddress);
+    }
+
+
 	/**
 	 * Handle dynamic method calls into the method.
 	 *

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -421,4 +421,105 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$sentry->getUser();
 	}
 
+    public function testFindGroupById()
+    {
+        $this->groupProvider->shouldReceive('findById')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findGroupByID(1));
+    }
+
+    public function testFindGroupByName()
+    {
+        $this->groupProvider->shouldReceive('findByName')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findGroupByName("name"));
+    }
+
+    public function testFindAllGroups()
+    {
+        $this->groupProvider->shouldReceive('findAll')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findAllGroups());
+    }
+
+    public function testCreateGroup()
+    {
+        $this->groupProvider->shouldReceive('create')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->createGroup(array()));
+    }
+
+    public function testFindUserByID()
+    {
+        $this->userProvider->shouldReceive('findById')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findUserById(1));
+    }
+    public function testFindUserByLogin()
+    {
+        $this->userProvider->shouldReceive('findByLogin')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findUserByLogin("login"));
+    }
+
+    public function testFindUserByCredentials()
+    {
+        $this->userProvider->shouldReceive('findByCredentials')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findUserByCredentials(array()));
+    }
+
+    public function testFindUserByActivationCode()
+    {
+        $this->userProvider->shouldReceive('findByActivationCode')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findUserByActivationCode("x"));
+    }
+
+    public function testFindUserByResetPasswordCode()
+    {
+        $this->userProvider->shouldReceive('findByResetPasswordCode')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findUserByResetPasswordCode("x"));
+    }
+
+    public function testFindAllUsers()
+    {
+        $this->userProvider->shouldReceive('findAll')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findAllUsers());
+    }
+
+    public function testFindAllUsersInGroup()
+    {
+        $this->userProvider->shouldReceive('findAllInGroup')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findAllUsersInGroup(""));
+    }
+
+    public function testFindAllUsersWithAccess()
+    {
+        $this->userProvider->shouldReceive('findAllWithAccess')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findAllUsersWithAccess(""));
+    }
+
+    public function testFindAllUsersWithAnyAccess()
+    {
+        $this->userProvider->shouldReceive('findAllWithAnyAccess')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findAllUsersWithAnyAccess(array()));
+    }
+
+    public function testCreateUser()
+    {
+        $this->userProvider->shouldReceive('create')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->createUser(array()));
+    }
+
+    public function testGetEmptyUser()
+    {
+        $this->userProvider->shouldReceive('getEmptyUser')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->getEmptyUser());
+    }
+
+    public function testFindThrottlerByUserID()
+    {
+        $this->throttleProvider->shouldReceive('findByUserId')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findThrottlerByUserId(1));
+    }
+
+    public function testFindThrottlerByUserLogin()
+    {
+        $this->throttleProvider->shouldReceive('findByUserLogin')->once()->andReturn(true);
+        $this->assertTrue($this->sentry->findThrottlerByUserLogin("X"));
+    }
+
 }


### PR DESCRIPTION
Rather than calling `Sentry::getUserProvider->findByID(1)`, I'd like to call `Sentry::findUserByID(1)`.  I don't need to know that Sentry uses Group/User/Throttle Providers -- this change hides that implementation knowledge from programmers.

This commit updates the docs and tests as well.
