### PR TITLE
Added prefix-based wildcard support to hasPermission() method

### DIFF
--- a/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
@@ -128,6 +128,28 @@ class Group extends Model implements GroupInterface {
 				}
 			}
 
+			// Now, let's check if the permission starts in a wildcard "*" symbol.
+			// If it does, we'll check through all the merged permissions to see
+			// if a permission exists which matches the wildcard.
+			elseif ((strlen($permission) > 1) and starts_with($permission, '*'))
+			{
+				$matched = false;
+
+				foreach ($groupPermissions as $groupPermission => $value)
+				{
+					// Strip the '*' off the start of the permission.
+					$checkPermission = substr($permission, 1);
+
+					// We will make sure that the merged permission does not
+					// exactly match our permission, but ends wtih it.
+					if ($checkPermission != $groupPermission and ends_with($groupPermission, $checkPermission) and $value == 1)
+					{
+						$matched = true;
+						break;
+					}
+				}
+			}
+
 			else
 			{
 				$matched = false;

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -629,6 +629,25 @@ class User extends Model implements UserInterface {
 					}
 				}
 			}
+			
+			elseif ((strlen($permission) > 1) and starts_with($permission, '*'))
+			{
+				$matched = false;
+
+				foreach ($mergedPermissions as $mergedPermission => $value)
+				{
+					// Strip the '*' off the beginning of the permission.
+					$checkPermission = substr($permission, 1);
+
+					// We will make sure that the merged permission does not
+					// exactly match our permission, but ends with it.
+					if ($checkPermission != $mergedPermission and ends_with($mergedPermission, $checkPermission) and $value == 1)
+					{
+						$matched = true;
+						break;
+					}
+				}
+			}
 
 			else
 			{


### PR DESCRIPTION
User and Group ->hasPermission() (called by hasAccess and hasAny) already supports suffix-based wildcard support. Prefix-based wildcard support could be added as a complement.
