### PR TITLE
Flush buffer for groups after add/remove operations in Eloquent\User mod...

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -490,6 +490,7 @@ class User extends Model implements UserInterface {
 		if ( ! $this->inGroup($group))
 		{
 			$this->groups()->attach($group);
+			$this->userGroups = null;
 		}
 
 		return true;
@@ -506,6 +507,7 @@ class User extends Model implements UserInterface {
 		if ($this->inGroup($group))
 		{
 			$this->groups()->detach($group);
+			$this->userGroups = null;
 		}
 
 		return true;


### PR DESCRIPTION
...el

We should flush cached `$this->userGroups` value after `attach()`/`detach()` group to/from user. Second solution for this is to append/delete group to/from buffer, but for appending case we don't know order into collection (it may be override in the `groups()` method). So it is a simplest implementation.
