### PR TITLE
phpDoc Fixes and Kohana typehint fix

### DIFF
--- a/src/Cartalyst/Sentry/Cookies/CICookie.php
+++ b/src/Cartalyst/Sentry/Cookies/CICookie.php
@@ -32,7 +32,7 @@ class CICookie implements CookieInterface {
 	/**
 	 * The CodeIgniter input object.
 	 *
-	 * @var CI_Input
+	 * @var \CI_Input
 	 */
 	protected $input;
 
@@ -46,7 +46,7 @@ class CICookie implements CookieInterface {
 	/**
 	 * Create a new CodeIgniter cookie driver for Sentry.
 	 *
-	 * @param  CI_Input  $input
+	 * @param  \CI_Input  $input
 	 * @param  array     $config
 	 * @param  string    $key
 	 */

--- a/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
+++ b/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
@@ -34,21 +34,21 @@ class IlluminateCookie implements CookieInterface {
 	/**
 	 * The cookie object.
 	 *
-	 * @var Illuminate\Cookie\CookieJar
+	 * @var \Illuminate\Cookie\CookieJar
 	 */
 	protected $jar;
 
 	/**
 	 * The cookie to be stored.
 	 *
-	 * @var Symfony\Component\HttpFoundation\Cookie
+	 * @var \Symfony\Component\HttpFoundation\Cookie
 	 */
 	protected $cookie;
 
 	/**
 	 * Creates a new cookie instance.
 	 *
-	 * @param  Illuminate\Cookie\CookieJar  $jar
+	 * @param  \Illuminate\Cookie\CookieJar  $jar
 	 * @param  string  $key
 	 * @return void
 	 */
@@ -119,7 +119,7 @@ class IlluminateCookie implements CookieInterface {
 	 * Returns the Symfony cookie object associated
 	 * with the Illuminate cookie.
 	 *
-	 * @return Symfony\Component\HttpFoundation\Cookie
+	 * @return \Symfony\Component\HttpFoundation\Cookie
 	 */
 	public function getCookie()
 	{

--- a/src/Cartalyst/Sentry/Facades/CI/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/CI/Sentry.php
@@ -51,6 +51,7 @@ class Sentry {
 	 * Creates a new instance of Sentry.
 	 *
 	 * @return \Cartalyst\Sentry\Sentry
+	 * @throws \RuntimeException
 	 */
 	public static function createSentry()
 	{

--- a/src/Cartalyst/Sentry/Facades/CI/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/CI/Sentry.php
@@ -50,7 +50,7 @@ class Sentry {
 	/**
 	 * Creates a new instance of Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Sentry
+	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function createSentry()
 	{

--- a/src/Cartalyst/Sentry/Facades/ConnectionResolver.php
+++ b/src/Cartalyst/Sentry/Facades/ConnectionResolver.php
@@ -55,15 +55,16 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	/**
 	 * The database connection.
 	 *
-	 * @var Illuminate\Database\Connection
+	 * @var \Illuminate\Database\Connection
 	 */
 	protected $connection;
 
 	/**
 	 * Create a new connection resolver.
 	 *
-	 * @param  PDO     $pdo
-	 * @param  string  $tablePrefix
+	 * @param  \PDO $pdo
+	 * @param  string $driverName
+	 * @param  string $tablePrefix
 	 * @return void
 	 */
 	public function __construct(PDO $pdo, $driverName, $tablePrefix = '')
@@ -77,7 +78,7 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	 * Get a database connection instance.
 	 *
 	 * @param  string  $name
-	 * @return Illuminate\Database\Connection
+	 * @return \Illuminate\Database\Connection
 	 */
 	public function connection($name = null)
 	{
@@ -108,7 +109,8 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	/**
 	 * Returns the database connection.
 	 *
-	 * @return Illuminate\Database\Connection
+	 * @return \Illuminate\Database\Connection
+	 * @throws \InvalidArgumentException
 	 */
 	public function getConnection()
 	{

--- a/src/Cartalyst/Sentry/Facades/Facade.php
+++ b/src/Cartalyst/Sentry/Facades/Facade.php
@@ -23,14 +23,14 @@ abstract class Facade {
 	/**
 	 * Sentry instance.
 	 *
-	 * @var Cartalyst\Sentry\Sentry
+	 * @var \Cartalyst\Sentry\Sentry
 	 */
 	protected static $instance;
 
 	/**
 	 * Returns the Sentry instance registered with the Facade.
 	 *
-	 * @return Cartalyst\Sentry\Sentry
+	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function instance()
 	{

--- a/src/Cartalyst/Sentry/Facades/FuelPHP/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/FuelPHP/Sentry.php
@@ -38,7 +38,7 @@ class Sentry extends Facade {
 	/**
 	 * Creates a new instance of Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Sentry
+	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function createSentry()
 	{

--- a/src/Cartalyst/Sentry/Facades/FuelPHP/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/FuelPHP/Sentry.php
@@ -39,6 +39,7 @@ class Sentry extends Facade {
 	 * Creates a new instance of Sentry.
 	 *
 	 * @return \Cartalyst\Sentry\Sentry
+	 * @throws \RuntimeException
 	 */
 	public static function createSentry()
 	{

--- a/src/Cartalyst/Sentry/Facades/Kohana/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/Kohana/Sentry.php
@@ -31,7 +31,7 @@ class Sentry extends Facade {
 	/**
 	 * Creates a new instance of Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Sentry
+	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function createSentry()
 	{

--- a/src/Cartalyst/Sentry/Facades/Native/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/Native/Sentry.php
@@ -40,12 +40,12 @@ class Sentry extends Facade {
 	/**
 	 * Creates a Sentry instance.
 	 *
-	 * @param  Cartalys\Sentry\Users\UserProvider           $userProvider
-	 * @param  Cartalys\Sentry\Groups\GroupProvider         $groupProvider
-	 * @param  Cartalys\Sentry\Throttling\ThrottleProvider  $throttleProvider
-	 * @param  Cartalys\Sentry\Sessions\SessionInterface    $session
-	 * @param  Cartalys\Sentry\Cookies\CookieInterface      $cookie
-	 * @return Cartalyst\Sentry\Sentry
+	 * @param  \Cartalyst\Sentry\Users\ProviderInterface       $userProvider
+	 * @param  \Cartalyst\Sentry\Groups\ProviderInterface      $groupProvider
+	 * @param  \Cartalyst\Sentry\Throttling\ProviderInterface  $throttleProvider
+	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface     $session
+	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface       $cookie
+	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function createSentry(
 		UserProviderInterface $userProvider = null,

--- a/src/Cartalyst/Sentry/Facades/Native/Sentry.php
+++ b/src/Cartalyst/Sentry/Facades/Native/Sentry.php
@@ -40,11 +40,12 @@ class Sentry extends Facade {
 	/**
 	 * Creates a Sentry instance.
 	 *
-	 * @param  \Cartalyst\Sentry\Users\ProviderInterface       $userProvider
-	 * @param  \Cartalyst\Sentry\Groups\ProviderInterface      $groupProvider
-	 * @param  \Cartalyst\Sentry\Throttling\ProviderInterface  $throttleProvider
-	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface     $session
-	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface       $cookie
+	 * @param  \Cartalyst\Sentry\Users\ProviderInterface $userProvider
+	 * @param  \Cartalyst\Sentry\Groups\ProviderInterface $groupProvider
+	 * @param  \Cartalyst\Sentry\Throttling\ProviderInterface $throttleProvider
+	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface $session
+	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface $cookie
+	 * @param  string $ipAddress
 	 * @return \Cartalyst\Sentry\Sentry
 	 */
 	public static function createSentry(

--- a/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
@@ -219,7 +219,7 @@ class Group extends Model implements GroupInterface {
 	/**
 	 * Returns the relationship between groups and users.
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
 	 */
 	public function users()
 	{
@@ -252,8 +252,9 @@ class Group extends Model implements GroupInterface {
 	/**
 	 * Mutator for giving permissions.
 	 *
-	 * @param  mixed  $permissions
-	 * @return array  $_permissions
+	 * @param  mixed $permissions
+	 * @return array
+	 * @throws \InvalidArgumentException
 	 */
 	public function getPermissionsAttribute($permissions)
 	{
@@ -280,6 +281,7 @@ class Group extends Model implements GroupInterface {
 	 *
 	 * @param  array  $permissions
 	 * @return void
+	 * @throws \InvalidArgumentException
 	 */
 	public function setPermissionsAttribute(array $permissions)
 	{

--- a/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
@@ -327,8 +327,8 @@ class Group extends Model implements GroupInterface {
 	 * Exceptions if validation fails.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Groups\NameRequiredException
-	 * @throws Cartalyst\Sentry\Groups\GroupExistsException
+	 * @throws \Cartalyst\Sentry\Groups\NameRequiredException
+	 * @throws \Cartalyst\Sentry\Groups\GroupExistsException
 	 */
 	public function validate()
 	{

--- a/src/Cartalyst/Sentry/Groups/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Provider.php
@@ -49,7 +49,7 @@ class Provider implements ProviderInterface {
 	 * Find the group by ID.
 	 *
 	 * @param  int  $id
-	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findById($id)
@@ -68,7 +68,7 @@ class Provider implements ProviderInterface {
 	 * Find the group by name.
 	 *
 	 * @param  string  $name
-	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findByName($name)
@@ -112,7 +112,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Create a new instance of the model.
 	 *
-	 * @return Illuminate\Database\Eloquent\Model
+	 * @return \Illuminate\Database\Eloquent\Model
 	 */
 	public function createModel()
 	{

--- a/src/Cartalyst/Sentry/Groups/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Provider.php
@@ -49,8 +49,8 @@ class Provider implements ProviderInterface {
 	 * Find the group by ID.
 	 *
 	 * @param  int  $id
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\Groups\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findById($id)
 	{
@@ -68,8 +68,8 @@ class Provider implements ProviderInterface {
 	 * Find the group by name.
 	 *
 	 * @param  string  $name
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\Groups\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findByName($name)
 	{
@@ -99,7 +99,7 @@ class Provider implements ProviderInterface {
 	 * Creates a group.
 	 *
 	 * @param  array  $attributes
-	 * @return Cartalyst\Sentry\Groups\GroupInterface
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface
 	 */
 	public function create(array $attributes)
 	{

--- a/src/Cartalyst/Sentry/Groups/Kohana/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Group.php
@@ -246,7 +246,7 @@ class Group extends \ORM implements GroupInterface {
 	/**
 	 * Saves the group.
 	 *
-	 * @param  array  $options
+	 * @param Validation $validation
 	 * @return bool
 	 */
 	public function save(Validation $validation = NULL)
@@ -275,6 +275,7 @@ class Group extends \ORM implements GroupInterface {
 	 *
 	 * @param  mixed  $permissions
 	 * @return array  $_permissions
+	 * @throws \InvalidArgumentException
 	 */
 	public function getPermissionsAttribute($permissions)
 	{
@@ -301,6 +302,7 @@ class Group extends \ORM implements GroupInterface {
 	 *
 	 * @param  array  $permissions
 	 * @return void
+	 * @throws \InvalidArgumentException
 	 */
 	public function setPermissionsAttribute(array $permissions)
 	{
@@ -359,9 +361,8 @@ class Group extends \ORM implements GroupInterface {
 	/**
 	 * Tests if a unique key value exists in the database.
 	 *
-	 * @param   mixed    the value to test
-	 * @param   string   field name
-	 * @param   string   table name
+	 * @param   mixed  $value  the value to test
+	 * @param   string $field  field name
 	 * @return  boolean
 	 */
 	public function unique_key_exists($value, $field)

--- a/src/Cartalyst/Sentry/Groups/Kohana/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Group.php
@@ -332,8 +332,8 @@ class Group extends \ORM implements GroupInterface {
 	 *
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Groups\NameRequiredException
-	 * @throws Cartalyst\Sentry\Groups\GroupExistsException
+	 * @throws \Cartalyst\Sentry\Groups\NameRequiredException
+	 * @throws \Cartalyst\Sentry\Groups\GroupExistsException
 	 */
 	public function validate()
 	{

--- a/src/Cartalyst/Sentry/Groups/Kohana/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Group.php
@@ -246,10 +246,10 @@ class Group extends \ORM implements GroupInterface {
 	/**
 	 * Saves the group.
 	 *
-	 * @param Validation $validation
+	 * @param \Validation $validation
 	 * @return bool
 	 */
-	public function save(Validation $validation = NULL)
+	public function save(\Validation $validation = NULL)
 	{
 		$this->validate();
 

--- a/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
@@ -49,7 +49,7 @@ class Provider implements ProviderInterface {
 	 * Find the group by ID.
 	 *
 	 * @param  int  $id
-	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findById($id)
@@ -70,7 +70,7 @@ class Provider implements ProviderInterface {
 	 * Find the group by name.
 	 *
 	 * @param  string  $name
-	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findByName($name)
@@ -117,7 +117,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Create a new instance of the model.
 	 *
-	 * @return Kohana_ORM
+	 * @return \ORM
 	 */
 	public function createModel()
 	{

--- a/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
@@ -49,8 +49,8 @@ class Provider implements ProviderInterface {
 	 * Find the group by ID.
 	 *
 	 * @param  int  $id
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\Groups\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findById($id)
 	{
@@ -70,8 +70,8 @@ class Provider implements ProviderInterface {
 	 * Find the group by name.
 	 *
 	 * @param  string  $name
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\Groups\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findByName($name)
 	{
@@ -103,7 +103,7 @@ class Provider implements ProviderInterface {
 	 * Creates a group.
 	 *
 	 * @param  array  $attributes
-	 * @return Cartalyst\Sentry\Groups\GroupInterface
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface
 	 */
 	public function create(array $attributes)
 	{

--- a/src/Cartalyst/Sentry/Groups/ProviderInterface.php
+++ b/src/Cartalyst/Sentry/Groups/ProviderInterface.php
@@ -24,8 +24,8 @@ interface ProviderInterface {
 	 * Find the group by ID.
 	 *
 	 * @param  int  $id
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findById($id);
 
@@ -33,8 +33,8 @@ interface ProviderInterface {
 	 * Find the group by name.
 	 *
 	 * @param  string  $name
-	 * @return Cartalyst\Sentry\GroupInterface  $group
-	 * @throws Cartalyst\Sentry\GroupNotFoundException
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
 	 */
 	public function findByName($name);
 
@@ -49,7 +49,7 @@ interface ProviderInterface {
 	 * Creates a group.
 	 *
 	 * @param  array  $attributes
-	 * @return Cartalyst\Sentry\Groups\GroupInterface
+	 * @return \Cartalyst\Sentry\Groups\GroupInterface
 	 */
 	public function create(array $attributes);
 

--- a/src/Cartalyst/Sentry/Hashing/NativeHasher.php
+++ b/src/Cartalyst/Sentry/Hashing/NativeHasher.php
@@ -23,8 +23,9 @@ class NativeHasher implements HasherInterface {
 	/**
 	 * Hash string.
 	 *
-	 * @param  string  $string
+	 * @param  string $string
 	 * @return string
+	 * @throws \RuntimeException
 	 */
 	public function hash($string)
 	{

--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -43,21 +43,21 @@ class Sentry {
 	 * are available for finding the user to set
 	 * here.
 	 *
-	 * @var Cartalyst\Sentry\Users\UserInterface
+	 * @var \Cartalyst\Sentry\Users\UserInterface
 	 */
 	protected $user;
 
 	/**
 	 * The session driver used by Sentry.
 	 *
-	 * @var Cartalyst\Sentry\Sessions\SessionInterface
+	 * @var \Cartalyst\Sentry\Sessions\SessionInterface
 	 */
 	protected $session;
 
 	/**
 	 * The cookie driver used by Sentry.
 	 *
-	 * @var Cartalyst\Sentry\Cookies\CookieInterface
+	 * @var \Cartalyst\Sentry\Cookies\CookieInterface
 	 */
 	protected $cookie;
 
@@ -66,7 +66,7 @@ class Sentry {
 	 * objects which implement the Sentry user
 	 * interface.
 	 *
-	 * @var Cartalyst\Sentry\Users\ProviderInterface
+	 * @var \Cartalyst\Sentry\Users\ProviderInterface
 	 */
 	protected $userProvider;
 
@@ -75,7 +75,7 @@ class Sentry {
 	 * objects which implement the Sentry group
 	 * interface.
 	 *
-	 * @var Cartalyst\Sentry\Groups\ProviderInterface
+	 * @var \Cartalyst\Sentry\Groups\ProviderInterface
 	 */
 	protected $groupProvider;
 
@@ -84,7 +84,7 @@ class Sentry {
 	 * objects which implement the Sentry throttling
 	 * interface.
 	 *
-	 * @var Cartalyst\Sentry\Throttling\ProviderInterface
+	 * @var \Cartalyst\Sentry\Throttling\ProviderInterface
 	 */
 	protected $throttleProvider;
 
@@ -98,11 +98,11 @@ class Sentry {
 	/**
 	 * Create a new Sentry object.
 	 *
-	 * @param  Cartalyst\Sentry\Sessions\SessionInterface  $session
-	 * @param  Cartalyst\Sentry\Cookies\CookieInterface  $cookie
-	 * @param  Cartalyst\Sentry\Users\UserProviderInterface  $userProvider
-	 * @param  Cartalyst\Sentry\Groups\GroupProviderInterface  $groupProvider
-	 * @param  Cartalyst\Sentry\Throttling\ThrottleProviderInterface  $throttleProvider
+	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface  $session
+	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface  $cookie
+	 * @param  \Cartalyst\Sentry\Users\UserProviderInterface  $userProvider
+	 * @param  \Cartalyst\Sentry\Groups\GroupProviderInterface  $groupProvider
+	 * @param  \Cartalyst\Sentry\Throttling\ThrottleProviderInterface  $throttleProvider
 	 * @param  string  $ipAddress
 	 * @return void
 	 */
@@ -134,7 +134,7 @@ class Sentry {
 	 *
 	 * @param  array  $credentials
 	 * @param  bool   $activate
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function register(array $credentials, $activate = false)
 	{
@@ -155,12 +155,12 @@ class Sentry {
 	 *
 	 * @param  array  $credentials
 	 * @param  bool   $remember
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Throttling\UserBannedException
-	 * @throws Cartalyst\Sentry\Throttling\UserSuspendedException
-	 * @throws Cartalyst\Sentry\Users\LoginRequiredException
-	 * @throws Cartalyst\Sentry\Users\PasswordRequiredException
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Throttling\UserBannedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserSuspendedException
+	 * @throws \Cartalyst\Sentry\Users\LoginRequiredException
+	 * @throws \Cartalyst\Sentry\Users\PasswordRequiredException
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function authenticate(array $credentials, $remember = false)
 	{
@@ -229,7 +229,7 @@ class Sentry {
 	 * Alias for authenticating with the remember flag checked.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function authenticateAndRemember(array $credentials)
 	{
@@ -308,10 +308,10 @@ class Sentry {
 	 * Logs in the given user and sets properties
 	 * in the session.
 	 *
-	 * @param  Cartalyst\Sentry\Users\UserInterface  $user
+	 * @param  \Cartalyst\Sentry\Users\UserInterface  $user
 	 * @param  bool  $remember
 	 * @return void
-	 * @throws Cartalyst\Sentry\Users\UserNotActivatedException
+	 * @throws \Cartalyst\Sentry\Users\UserNotActivatedException
 	 */
 	public function login(UserInterface $user, $remember = false)
 	{
@@ -342,7 +342,7 @@ class Sentry {
 	/**
 	 * Alias for logging in and remembering.
 	 *
-	 * @param  Cartalyst\Sentry\Users\UserInterface  $user
+	 * @param  \Cartalyst\Sentry\Users\UserInterface  $user
 	 */
 	public function loginAndRemember(UserInterface $user)
 	{
@@ -365,7 +365,7 @@ class Sentry {
 	/**
 	 * Sets the user to be used by Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Users\UserInterface
+	 * @param  \Cartalyst\Sentry\Users\UserInterface
 	 * @return void
 	 */
 	public function setUser(UserInterface $user)
@@ -376,7 +376,7 @@ class Sentry {
 	/**
 	 * Returns the current user being used by Sentry, if any.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getUser()
 	{
@@ -392,7 +392,7 @@ class Sentry {
 	/**
 	 * Sets the session driver for Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Sessions\SessionInterface  $session
+	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface  $session
 	 * @return void
 	 */
 	public function setSession(SessionInterface $session)
@@ -403,7 +403,7 @@ class Sentry {
 	/**
 	 * Gets the session driver for Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Sessions\SessionInterface
+	 * @return \Cartalyst\Sentry\Sessions\SessionInterface
 	 */
 	public function getSession()
 	{
@@ -413,7 +413,7 @@ class Sentry {
 	/**
 	 * Sets the cookie driver for Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Cookies\CookieInterface  $cookie
+	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface  $cookie
 	 * @return void
 	 */
 	public function setCookie(CookieInterface $cookie)
@@ -424,7 +424,7 @@ class Sentry {
 	/**
 	 * Gets the cookie driver for Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Cookies\CookieInterface
+	 * @return \Cartalyst\Sentry\Cookies\CookieInterface
 	 */
 	public function getCookie()
 	{
@@ -434,7 +434,7 @@ class Sentry {
 	/**
 	 * Sets the group provider for Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\ProviderInterface
+	 * @param  \Cartalyst\Sentry\Groups\ProviderInterface
 	 * @return void
 	 */
 	public function setGroupProvider(GroupProviderInterface $groupProvider)
@@ -445,7 +445,7 @@ class Sentry {
 	/**
 	 * Gets the group provider for Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Groups\ProviderInterface
+	 * @return \Cartalyst\Sentry\Groups\ProviderInterface
 	 */
 	public function getGroupProvider()
 	{
@@ -455,7 +455,7 @@ class Sentry {
 	/**
 	 * Sets the user provider for Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Users\ProviderInterface
+	 * @param  \Cartalyst\Sentry\Users\ProviderInterface
 	 * @return void
 	 */
 	public function setUserProvider(UserProviderInterface $userProvider)
@@ -466,7 +466,7 @@ class Sentry {
 	/**
 	 * Gets the user provider for Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Users\ProviderInterface
+	 * @return \Cartalyst\Sentry\Users\ProviderInterface
 	 */
 	public function getUserProvider()
 	{
@@ -476,7 +476,7 @@ class Sentry {
 	/**
 	 * Sets the throttle provider for Sentry.
 	 *
-	 * @param  Cartalyst\Sentry\Throttling\ProviderInterface
+	 * @param  \Cartalyst\Sentry\Throttling\ProviderInterface
 	 * @return void
 	 */
 	public function setThrottleProvider(ThrottleProviderInterface $throttleProvider)
@@ -487,7 +487,7 @@ class Sentry {
 	/**
 	 * Gets the throttle provider for Sentry.
 	 *
-	 * @return Cartalyst\Sentry\Throttling\ProviderInterface
+	 * @return \Cartalyst\Sentry\Throttling\ProviderInterface
 	 */
 	public function getThrottleProvider()
 	{
@@ -519,8 +519,8 @@ class Sentry {
      * Find the group by ID.
      *
      * @param  int  $id
-     * @return Cartalyst\Sentry\GroupInterface  $group
-     * @throws Cartalyst\Sentry\GroupNotFoundException
+     * @return \Cartalyst\Sentry\GroupInterface  $group
+     * @throws \Cartalyst\Sentry\GroupNotFoundException
      */
     public function findGroupById($id)
     {
@@ -531,8 +531,8 @@ class Sentry {
      * Find the group by name.
      *
      * @param  string  $name
-     * @return Cartalyst\Sentry\GroupInterface  $group
-     * @throws Cartalyst\Sentry\GroupNotFoundException
+     * @return \Cartalyst\Sentry\GroupInterface  $group
+     * @throws \Cartalyst\Sentry\GroupNotFoundException
      */
     public function findGroupByName($name)
     {
@@ -553,7 +553,7 @@ class Sentry {
      * Creates a group.
      *
      * @param  array  $attributes
-     * @return Cartalyst\Sentry\Groups\GroupInterface
+     * @return \Cartalyst\Sentry\Groups\GroupInterface
      */
     public function createGroup(array $attributes)
     {
@@ -565,8 +565,8 @@ class Sentry {
      * Finds a user by the given user ID.
      *
      * @param  mixed  $id
-     * @return Cartalyst\Sentry\Users\UserInterface
-     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     * @return \Cartalyst\Sentry\Users\UserInterface
+     * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserById($id)
     {
@@ -577,8 +577,8 @@ class Sentry {
      * Finds a user by the login value.
      *
      * @param  string  $login
-     * @return Cartalyst\Sentry\Users\UserInterface
-     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     * @return \Cartalyst\Sentry\Users\UserInterface
+     * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByLogin($login)
     {
@@ -589,8 +589,8 @@ class Sentry {
      * Finds a user by the given credentials.
      *
      * @param  array  $credentials
-     * @return Cartalyst\Sentry\Users\UserInterface
-     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     * @return \Cartalyst\Sentry\Users\UserInterface
+     * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByCredentials(array $credentials){
         return $this->userProvider->findByCredentials($credentials);
@@ -600,9 +600,9 @@ class Sentry {
      * Finds a user by the given activation code.
      *
      * @param  string  $code
-     * @return Cartalyst\Sentry\Users\UserInterface
+     * @return \Cartalyst\Sentry\Users\UserInterface
      * @throws RuntimeException
-     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByActivationCode($code)
     {
@@ -613,9 +613,9 @@ class Sentry {
      * Finds a user by the given reset password code.
      *
      * @param  string  $code
-     * @return Cartalyst\Sentry\Users\UserInterface
+     * @return \Cartalyst\Sentry\Users\UserInterface
      * @throws RuntimeException
-     * @throws Cartalyst\Sentry\Users\UserNotFoundException
+     * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByResetPasswordCode($code)
     {
@@ -636,7 +636,7 @@ class Sentry {
      * Returns all users who belong to
      * a group.
      *
-     * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+     * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
      * @return array
      */
     public function findAllUsersInGroup($group)
@@ -672,7 +672,7 @@ class Sentry {
      * Creates a user.
      *
      * @param  array  $credentials
-     * @return Cartalyst\Sentry\Users\UserInterface
+     * @return \Cartalyst\Sentry\Users\UserInterface
      */
     public function createUser(array $credentials)
     {
@@ -682,7 +682,7 @@ class Sentry {
     /**
      * Returns an empty user object.
      *
-     * @return Cartalyst\Sentry\Users\UserInterface
+     * @return \Cartalyst\Sentry\Users\UserInterface
      */
     public function getEmptyUser()
     {
@@ -694,7 +694,7 @@ class Sentry {
      *
      * @param  mixed   $id
      * @param  string  $ipAddress
-     * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+     * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
      */
     public function findThrottlerByUserId($id, $ipAddress = null)
     {
@@ -706,7 +706,7 @@ class Sentry {
      *
      * @param  string  $login
      * @param  string  $ipAddress
-     * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+     * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
      */
     public function findThrottlerByUserLogin($login, $ipAddress = null)
     {

--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -98,12 +98,12 @@ class Sentry {
 	/**
 	 * Create a new Sentry object.
 	 *
-	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface  $session
-	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface  $cookie
-	 * @param  \Cartalyst\Sentry\Users\UserProviderInterface  $userProvider
-	 * @param  \Cartalyst\Sentry\Groups\GroupProviderInterface  $groupProvider
-	 * @param  \Cartalyst\Sentry\Throttling\ThrottleProviderInterface  $throttleProvider
-	 * @param  string  $ipAddress
+	 * @param  \Cartalyst\Sentry\Users\ProviderInterface $userProvider
+	 * @param  \Cartalyst\Sentry\Groups\ProviderInterface $groupProvider
+	 * @param  \Cartalyst\Sentry\Throttling\ProviderInterface $throttleProvider
+	 * @param  \Cartalyst\Sentry\Sessions\SessionInterface $session
+	 * @param  \Cartalyst\Sentry\Cookies\CookieInterface $cookie
+	 * @param  string $ipAddress
 	 * @return void
 	 */
 	public function __construct(
@@ -519,8 +519,8 @@ class Sentry {
      * Find the group by ID.
      *
      * @param  int  $id
-     * @return \Cartalyst\Sentry\GroupInterface  $group
-     * @throws \Cartalyst\Sentry\GroupNotFoundException
+     * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
+     * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
      */
     public function findGroupById($id)
     {
@@ -531,8 +531,8 @@ class Sentry {
      * Find the group by name.
      *
      * @param  string  $name
-     * @return \Cartalyst\Sentry\GroupInterface  $group
-     * @throws \Cartalyst\Sentry\GroupNotFoundException
+     * @return \Cartalyst\Sentry\Groups\GroupInterface  $group
+     * @throws \Cartalyst\Sentry\Groups\GroupNotFoundException
      */
     public function findGroupByName($name)
     {
@@ -601,7 +601,7 @@ class Sentry {
      *
      * @param  string  $code
      * @return \Cartalyst\Sentry\Users\UserInterface
-     * @throws RuntimeException
+     * @throws \RuntimeException
      * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByActivationCode($code)
@@ -614,7 +614,7 @@ class Sentry {
      *
      * @param  string  $code
      * @return \Cartalyst\Sentry\Users\UserInterface
-     * @throws RuntimeException
+     * @throws \RuntimeException
      * @throws \Cartalyst\Sentry\Users\UserNotFoundException
      */
     public function findUserByResetPasswordCode($code)
@@ -719,7 +719,7 @@ class Sentry {
 	 * @param  string  $method
 	 * @param  array   $parameters
 	 * @return mixed
-	 * @throws BadMethodCallException
+	 * @throws \BadMethodCallException
 	 */
 	public function __call($method, $parameters)
 	{

--- a/src/Cartalyst/Sentry/Sessions/CISession.php
+++ b/src/Cartalyst/Sentry/Sessions/CISession.php
@@ -39,7 +39,7 @@ class CISession implements SessionInterface {
 	/**
 	 * Creates a new CodeIgniter Session driver for Sentry.
 	 *
-	 * @param  CI_Session  $store
+	 * @param  \CI_Session  $store
 	 * @param  string  $key
 	 * @return void
 	 */

--- a/src/Cartalyst/Sentry/Sessions/FuelPHPSession.php
+++ b/src/Cartalyst/Sentry/Sessions/FuelPHPSession.php
@@ -39,7 +39,7 @@ class FuelPHPSession implements SessionInterface {
 	/**
 	 * Creates a new FuelPHP Session driver for Sentry.
 	 *
-	 * @param  Fuel\Core\Session_Driver  $store
+	 * @param  \Fuel\Core\Session_Driver  $store
 	 * @param  string  $key
 	 * @return void
 	 */

--- a/src/Cartalyst/Sentry/Sessions/IlluminateSession.php
+++ b/src/Cartalyst/Sentry/Sessions/IlluminateSession.php
@@ -32,14 +32,14 @@ class IlluminateSession implements SessionInterface {
 	/**
 	 * Session store object.
 	 *
-	 * @var Illuminate\Session\Store
+	 * @var \Illuminate\Session\Store
 	 */
 	protected $session;
 
 	/**
 	 * Creates a new Illuminate based Session driver for Sentry.
 	 *
-	 * @param  Illuminate\Session\Store  $session
+	 * @param  \Illuminate\Session\Store  $session
 	 * @param  string  $key
 	 * @return void
 	 */

--- a/src/Cartalyst/Sentry/Sessions/KohanaSession.php
+++ b/src/Cartalyst/Sentry/Sessions/KohanaSession.php
@@ -18,8 +18,6 @@
  * @link       http://cartalyst.com
  */
 
-use Session;
-
 class KohanaSession implements SessionInterface {
 
 	/**
@@ -39,11 +37,11 @@ class KohanaSession implements SessionInterface {
 	/**
 	 * Creates a new Kohana Session driver for Sentry.
 	 *
-	 * @param  Session  $store
+	 * @param  \Session  $store
 	 * @param  string  $key
 	 * @return void
 	 */
-	public function __construct(Session $store, $key = null)
+	public function __construct(\Session $store, $key = null)
 	{
 		$this->store = $store;
 

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
@@ -49,7 +49,8 @@ class Provider implements ProviderInterface {
 	/**
 	 * Creates a new throttle provider.
 	 *
-	 * @param  \Cartalyst\Sentry\Users\UserInterface  $userProvider
+	 * @param \Cartalyst\Sentry\Users\ProviderInterface $userProvider
+	 * @param  string $model
 	 * @return void
 	 */
 	public function __construct(UserProviderInterface $userProvider, $model = null)
@@ -158,7 +159,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Create a new instance of the model.
 	 *
-	 * @return Illuminate\Database\Eloquent\Model
+	 * @return \Illuminate\Database\Eloquent\Model
 	 */
 	public function createModel()
 	{

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
@@ -35,7 +35,7 @@ class Provider implements ProviderInterface {
 	 * The user provider used for finding users
 	 * to attach throttles to.
 	 *
-	 * @var Cartalyst\Sentry\Users\UserInterface
+	 * @var \Cartalyst\Sentry\Users\UserInterface
 	 */
 	protected $userProvider;
 
@@ -49,7 +49,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Creates a new throttle provider.
 	 *
-	 * @param  Cartalyst\Sentry\Users\UserInterface  $userProvider
+	 * @param  \Cartalyst\Sentry\Users\UserInterface  $userProvider
 	 * @return void
 	 */
 	public function __construct(UserProviderInterface $userProvider, $model = null)
@@ -67,7 +67,7 @@ class Provider implements ProviderInterface {
 	 *
 	 * @param  mixed   $id
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserId($id, $ipAddress = null)
 	{
@@ -98,7 +98,7 @@ class Provider implements ProviderInterface {
 	 *
 	 * @param  string  $login
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserLogin($login, $ipAddress = null)
 	{

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
@@ -257,7 +257,7 @@ class Throttle extends Model implements ThrottleInterface {
 	/**
 	 * User relationship for the throttle.
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\BelongsTo
+	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
 	public function user()
 	{
@@ -410,7 +410,7 @@ class Throttle extends Model implements ThrottleInterface {
 	/**
 	 * Get suspension time.
 	 *
-	 * @param  int
+	 * @return  int
 	 */
 	public static function getSuspensionTime()
 	{

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
@@ -71,7 +71,7 @@ class Throttle extends Model implements ThrottleInterface {
 	/**
 	 * Returns the associated user with the throttler.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getUser()
 	{
@@ -230,8 +230,8 @@ class Throttle extends Model implements ThrottleInterface {
 	 * Check user throttle status.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Throttling\UserBannedException
-	 * @throws Cartalyst\Sentry\Throttling\UserSuspendedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserBannedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserSuspendedException
 	 */
 	public function check()
 	{

--- a/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
@@ -35,7 +35,7 @@ class Provider implements ProviderInterface {
 	 * The user provider used for finding users
 	 * to attach throttles to.
 	 *
-	 * @var \Cartalyst\Sentry\Users\UserInterface
+	 * @var \Cartalyst\Sentry\Users\ProviderInterface
 	 */
 	protected $userProvider;
 
@@ -49,7 +49,8 @@ class Provider implements ProviderInterface {
 	/**
 	 * Creates a new throttle provider.
 	 *
-	 * @param  \Cartalyst\Sentry\Users\UserInterface  $userProvider
+	 * @param  \Cartalyst\Sentry\Users\ProviderInterface $userProvider
+	 * @param  string $model
 	 * @return void
 	 */
 	public function __construct(UserProviderInterface $userProvider, $model = null)
@@ -165,7 +166,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Create a new instance of the model.
 	 *
-	 * @return Kohana_ORM
+	 * @return \ORM
 	 */
 	public function createModel()
 	{

--- a/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
@@ -35,7 +35,7 @@ class Provider implements ProviderInterface {
 	 * The user provider used for finding users
 	 * to attach throttles to.
 	 *
-	 * @var Cartalyst\Sentry\Users\UserInterface
+	 * @var \Cartalyst\Sentry\Users\UserInterface
 	 */
 	protected $userProvider;
 
@@ -49,7 +49,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Creates a new throttle provider.
 	 *
-	 * @param  Cartalyst\Sentry\Users\UserInterface  $userProvider
+	 * @param  \Cartalyst\Sentry\Users\UserInterface  $userProvider
 	 * @return void
 	 */
 	public function __construct(UserProviderInterface $userProvider, $model = null)
@@ -67,7 +67,7 @@ class Provider implements ProviderInterface {
 	 *
 	 * @param  mixed   $id
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserId($id, $ipAddress = null)
 	{
@@ -104,7 +104,7 @@ class Provider implements ProviderInterface {
 	 *
 	 * @param  string  $login
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserLogin($login, $ipAddress = null)
 	{

--- a/src/Cartalyst/Sentry/Throttling/Kohana/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Kohana/Throttle.php
@@ -75,7 +75,7 @@ class Throttle extends \ORM implements ThrottleInterface {
 	/**
 	 * Returns the associated user with the throttler.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getUser()
 	{
@@ -234,8 +234,8 @@ class Throttle extends \ORM implements ThrottleInterface {
 	 * Check user throttle status.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Throttling\UserBannedException
-	 * @throws Cartalyst\Sentry\Throttling\UserSuspendedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserBannedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserSuspendedException
 	 */
 	public function check(Validation $extra_validation = NULL)
 	{

--- a/src/Cartalyst/Sentry/Throttling/Kohana/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Kohana/Throttle.php
@@ -233,11 +233,12 @@ class Throttle extends \ORM implements ThrottleInterface {
 	/**
 	 * Check user throttle status.
 	 *
+	 * @param \Validation $extra_validation
 	 * @return bool
 	 * @throws \Cartalyst\Sentry\Throttling\UserBannedException
 	 * @throws \Cartalyst\Sentry\Throttling\UserSuspendedException
 	 */
-	public function check(Validation $extra_validation = NULL)
+	public function check(\Validation $extra_validation = NULL)
 	{
 		if ($this->isBanned())
 		{
@@ -376,7 +377,7 @@ class Throttle extends \ORM implements ThrottleInterface {
 	/**
 	 * Get suspension time.
 	 *
-	 * @param  int
+	 * @return int
 	 */
 	public static function getSuspensionTime()
 	{

--- a/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
+++ b/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
@@ -25,7 +25,7 @@ interface ProviderInterface {
 	 *
 	 * @param  mixed   $id
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserId($id, $ipAddress = null);
 
@@ -34,7 +34,7 @@ interface ProviderInterface {
 	 *
 	 * @param  string  $login
 	 * @param  string  $ipAddress
-	 * @return Cartalyst\Sentry\Throttling\ThrottleInterface
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
 	public function findByUserLogin($login, $ipAddress = null);
 

--- a/src/Cartalyst/Sentry/Throttling/ThrottleInterface.php
+++ b/src/Cartalyst/Sentry/Throttling/ThrottleInterface.php
@@ -23,7 +23,7 @@ interface ThrottleInterface {
 	/**
 	 * Returns the associated user with the throttler.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getUser();
 
@@ -94,8 +94,8 @@ interface ThrottleInterface {
 	 * Check user throttle status.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Throttling\UserBannedException
-	 * @throws Cartalyst\Sentry\Throttling\UserSuspendedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserBannedException
+	 * @throws \Cartalyst\Sentry\Throttling\UserSuspendedException
 	 */
 	public function check();
 

--- a/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
@@ -38,14 +38,14 @@ class Provider implements ProviderInterface {
 	/**
 	 * The hasher for the model.
 	 *
-	 * @var Cartalyst\Sentry\Hashing\HasherInterface
+	 * @var \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	protected $hasher;
 
 	/**
 	 * Create a new Eloquent User provider.
 	 *
-	 * @param  Cartalyst\Sentry\Hashing\HasherInterface  $hasher
+	 * @param  \Cartalyst\Sentry\Hashing\HasherInterface  $hasher
 	 * @param  string  $model
 	 * @return void
 	 */
@@ -65,8 +65,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given user ID.
 	 *
 	 * @param  mixed  $id
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findById($id)
 	{
@@ -84,8 +84,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the login value.
 	 *
 	 * @param  string  $login
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByLogin($login)
 	{
@@ -103,8 +103,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given credentials.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByCredentials(array $credentials)
 	{
@@ -165,8 +165,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given activation code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 * @throws InvalidArgumentException
 	 * @throws RuntimeException
 	 */
@@ -198,9 +198,9 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given reset password code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 * @throws RuntimeException
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByResetPasswordCode($code)
 	{
@@ -235,7 +235,7 @@ class Provider implements ProviderInterface {
 	 * Returns all users who belong to
 	 * a group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return array
 	 */
 	public function findAllInGroup($group)
@@ -280,7 +280,7 @@ class Provider implements ProviderInterface {
 	 * Creates a user.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function create(array $credentials)
 	{
@@ -294,7 +294,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Returns an empty user object.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getEmptyUser()
 	{

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -92,7 +92,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * The hasher the model uses.
 	 *
-	 * @var Cartalyst\Sentry\Hashing\HasherInterface
+	 * @var \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	protected static $hasher;
 
@@ -263,9 +263,9 @@ class User extends Model implements UserInterface {
 	 * Exceptions if validation fails.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Users\LoginRequiredException
-	 * @throws Cartalyst\Sentry\Users\PasswordRequiredException
-	 * @throws Cartalyst\Sentry\Users\UserExistsException
+	 * @throws \Cartalyst\Sentry\Users\LoginRequiredException
+	 * @throws \Cartalyst\Sentry\Users\PasswordRequiredException
+	 * @throws \Cartalyst\Sentry\Users\UserExistsException
 	 */
 	public function validate()
 	{
@@ -371,7 +371,7 @@ class User extends Model implements UserInterface {
 	 *
 	 * @param  string  $activationCode
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Users\UserAlreadyActivatedException
+	 * @throws \Cartalyst\Sentry\Users\UserAlreadyActivatedException
 	 */
 	public function attemptActivation($activationCode)
 	{
@@ -482,7 +482,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * Adds the user to the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function addGroup(GroupInterface $group)
@@ -498,7 +498,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * Removes the user from the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function removeGroup(GroupInterface $group)
@@ -514,7 +514,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * See if the user is in the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function inGroup(GroupInterface $group)
@@ -867,7 +867,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * Sets the hasher for the user.
 	 *
-	 * @param  Cartalyst\Sentry\Hashing\HasherInterface  $hasher
+	 * @param \Cartalyst\Sentry\Hashing\HasherInterface $hasher
 	 * @return void
 	 */
 	public static function setHasher(HasherInterface $hasher)
@@ -878,7 +878,7 @@ class User extends Model implements UserInterface {
 	/**
 	 * Returns the hasher for the user.
 	 *
-	 * @return Cartalyst\Sentry\Hashing\HasherInterface
+	 * @return \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	public static function getHasher()
 	{

--- a/src/Cartalyst/Sentry/Users/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/Provider.php
@@ -38,14 +38,14 @@ class Provider implements ProviderInterface {
 	/**
 	 * The hasher for the model.
 	 *
-	 * @var Cartalyst\Sentry\Hashing\HasherInterface
+	 * @var \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	protected $hasher;
 
 	/**
 	 * Create a new ORM User provider.
 	 *
-	 * @param  Cartalyst\Sentry\Hashing\HasherInterface  $hasher
+	 * @param  \Cartalyst\Sentry\Hashing\HasherInterface  $hasher
 	 * @param  string  $model
 	 * @return void
 	 */
@@ -65,8 +65,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given user ID.
 	 *
 	 * @param  mixed  $id
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findById($id)
 	{
@@ -86,8 +86,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the login value.
 	 *
 	 * @param  string  $login
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByLogin($login)
 	{
@@ -107,8 +107,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given credentials.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByCredentials(array $credentials)
 	{
@@ -170,8 +170,8 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given activation code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 * @throws InvalidArgumentException
 	 * @throws RuntimeException
 	 */
@@ -205,9 +205,9 @@ class Provider implements ProviderInterface {
 	 * Finds a user by the given reset password code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 * @throws RuntimeException
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByResetPasswordCode($code)
 	{
@@ -244,7 +244,7 @@ class Provider implements ProviderInterface {
 	 * Returns all users who belong to
 	 * a group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return array
 	 */
 	public function findAllInGroup($group)
@@ -289,7 +289,7 @@ class Provider implements ProviderInterface {
 	 * Creates a user.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function create(array $credentials)
 	{
@@ -303,7 +303,7 @@ class Provider implements ProviderInterface {
 	/**
 	 * Returns an empty user object.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getEmptyUser()
 	{

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -299,10 +299,10 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Saves the user.
 	 *
-	 * @param  Validation  $validation
+	 * @param  \Validation  $validation
 	 * @return bool
 	 */
-	public function save(Validation $validation = NULL)
+	public function save(\Validation $validation = NULL)
 	{
 		$this->validate();
 

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -289,7 +289,7 @@ class User extends \ORM implements UserInterface {
 	 * Exceptions if validation fails.
 	 *
 	 * @return bool
-	 * @throws ORM_Validation_Exception
+	 * @throws \ORM_Validation_Exception
 	 */
 	public function validate()
 	{
@@ -299,7 +299,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Saves the user.
 	 *
-	 * @param  array  $options
+	 * @param  Validation  $validation
 	 * @return bool
 	 */
 	public function save(Validation $validation = NULL)
@@ -753,7 +753,7 @@ class User extends \ORM implements UserInterface {
 	 * @param  string  $string
 	 * @param  string  $hashedString
 	 * @return bool
-	 * @throws RuntimeException
+	 * @throws \RuntimeException
 	 */
 	public function checkHash($string, $hashedString)
 	{
@@ -770,7 +770,7 @@ class User extends \ORM implements UserInterface {
 	 *
 	 * @param  string  $string
 	 * @return string
-	 * @throws RuntimeException
+	 * @throws \RuntimeException
 	 */
 	public function hash($string)
 	{
@@ -784,7 +784,9 @@ class User extends \ORM implements UserInterface {
 
 	/**
 	 * Generate a random string. If your server has
+	 * @param int $length
 	 * @return string
+	 * @throws \RuntimeException
 	 */
 	public function getRandomString($length = 42)
 	{
@@ -877,9 +879,8 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Tests if a unique key value exists in the database.
 	 *
-	 * @param   mixed    the value to test
-	 * @param   string   field name
-	 * @param   string   table name
+	 * @param   mixed  $value  the value to test
+	 * @param   string $field  field name
 	 * @return  boolean
 	 */
 	public function unique_key_exists($value, $field = NULL)
@@ -903,7 +904,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Allows a model use both email and username as unique identifiers for login
 	 *
-	 * @param   string  unique value
+	 * @param   string $value unique value
 	 * @return  string  field name
 	 */
 	public function unique_key($value)

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -118,7 +118,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * The hasher the model uses.
 	 *
-	 * @var Cartalyst\Sentry\Hashing\HasherInterface
+	 * @var \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	protected static $hasher;
 
@@ -400,7 +400,7 @@ class User extends \ORM implements UserInterface {
 	 *
 	 * @param  string  $activationCode
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Users\UserAlreadyActivatedException
+	 * @throws \Cartalyst\Sentry\Users\UserAlreadyActivatedException
 	 */
 	public function attemptActivation($activationCode)
 	{
@@ -511,7 +511,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Adds the user to the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function addGroup(GroupInterface $group)
@@ -527,7 +527,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Removes the user from the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function removeGroup(GroupInterface $group)
@@ -543,7 +543,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * See if the user is in the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function inGroup(GroupInterface $group)
@@ -825,7 +825,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Sets the hasher for the user.
 	 *
-	 * @param  Cartalyst\Sentry\Hashing\HasherInterface  $hasher
+	 * @param \Cartalyst\Sentry\Hashing\HasherInterface  $hasher
 	 * @return void
 	 */
 	public static function setHasher(HasherInterface $hasher)
@@ -836,7 +836,7 @@ class User extends \ORM implements UserInterface {
 	/**
 	 * Returns the hasher for the user.
 	 *
-	 * @return Cartalyst\Sentry\Hashing\HasherInterface
+	 * @return \Cartalyst\Sentry\Hashing\HasherInterface
 	 */
 	public static function getHasher()
 	{

--- a/src/Cartalyst/Sentry/Users/ProviderInterface.php
+++ b/src/Cartalyst/Sentry/Users/ProviderInterface.php
@@ -26,8 +26,8 @@ interface ProviderInterface {
 	 * Finds a user by the given user ID.
 	 *
 	 * @param  mixed  $id
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findById($id);
 
@@ -35,8 +35,8 @@ interface ProviderInterface {
 	 * Finds a user by the login value.
 	 *
 	 * @param  string  $login
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByLogin($login);
 
@@ -44,8 +44,8 @@ interface ProviderInterface {
 	 * Finds a user by the given credentials.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByCredentials(array $credentials);
 
@@ -53,8 +53,8 @@ interface ProviderInterface {
 	 * Finds a user by the given activation code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @return \Cartalyst\Sentry\Users\UserInterface
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 * @throws InvalidArgumentException
 	 * @throws RuntimeException
 	 */
@@ -64,9 +64,9 @@ interface ProviderInterface {
 	 * Finds a user by the given reset password code.
 	 *
 	 * @param  string  $code
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 * @throws RuntimeException
-	 * @throws Cartalyst\Sentry\Users\UserNotFoundException
+	 * @throws \Cartalyst\Sentry\Users\UserNotFoundException
 	 */
 	public function findByResetPasswordCode($code);
 
@@ -81,7 +81,7 @@ interface ProviderInterface {
 	 * Returns all users who belong to
 	 * a group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return array
 	 */
 	public function findAllInGroup($group);
@@ -108,14 +108,14 @@ interface ProviderInterface {
 	 * Creates a user.
 	 *
 	 * @param  array  $credentials
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function create(array $credentials);
 
 	/**
 	 * Returns an empty user object.
 	 *
-	 * @return Cartalyst\Sentry\Users\UserInterface
+	 * @return \Cartalyst\Sentry\Users\UserInterface
 	 */
 	public function getEmptyUser();
 

--- a/src/Cartalyst/Sentry/Users/UserInterface.php
+++ b/src/Cartalyst/Sentry/Users/UserInterface.php
@@ -84,8 +84,8 @@ interface UserInterface {
 	 * Exceptions if validation fails.
 	 *
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Users\LoginRequiredException
-	 * @throws Cartalyst\Sentry\Users\UserExistsException
+	 * @throws \Cartalyst\Sentry\Users\LoginRequiredException
+	 * @throws \Cartalyst\Sentry\Users\UserExistsException
 	 */
 	public function validate();
 
@@ -134,7 +134,7 @@ interface UserInterface {
 	 *
 	 * @param  string  $activationCode
 	 * @return bool
-	 * @throws Cartalyst\Sentry\Users\UserAlreadyActivatedException
+	 * @throws \Cartalyst\Sentry\Users\UserAlreadyActivatedException
 	 */
 	public function attemptActivation($activationCode);
 
@@ -191,7 +191,7 @@ interface UserInterface {
 	/**
 	 * Adds the user to the given group
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function addGroup(GroupInterface $group);
@@ -199,7 +199,7 @@ interface UserInterface {
 	/**
 	 * Removes the user from the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function removeGroup(GroupInterface $group);
@@ -207,7 +207,7 @@ interface UserInterface {
 	/**
 	 * See if the user is in the given group.
 	 *
-	 * @param  Cartalyst\Sentry\Groups\GroupInterface  $group
+	 * @param  \Cartalyst\Sentry\Groups\GroupInterface  $group
 	 * @return bool
 	 */
 	public function inGroup(GroupInterface $group);


### PR DESCRIPTION
Hey There,

In this PR I hope to have achieved to have corrected almost every phpDoc.

All Cartalyst\Sentry types have been prefixed with a backslash. Such as it now types for `\Cartalyst\Sentry\Groups\ProviderInterface` not `\Cartalyst\Sentry\Cartalyst\Sentry\Groups\ProviderInterface`.

Also in this PR is what I believe to be a [bug](https://github.com/Lavoaster/sentry/commit/701523a5fda0952ca216c8219a2e1784359875d7#L8L252) in which you typehint for Validation but since there is no import for it it would infact be typehinting for `Cartalyst\Sentry\Groups\Kohana\Validation`.
