### PR TITLE
Fixed Kohana's permission checks

### DIFF
--- a/src/Cartalyst/Sentry/Groups/Kohana/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Group.php
@@ -136,7 +136,7 @@ class Group extends \ORM implements GroupInterface {
 			// Now, let's check if the permission ends in a wildcard "*" symbol.
 			// If it does, we'll check through all the merged permissions to see
 			// if a permission exists which matches the wildcard.
-			if ((strlen($permission) > 1) and Text::ends_with($permission, '*'))
+			if ((strlen($permission) > 1) and \Text::ends_with($permission, '*'))
 			{
 				$matched = false;
 
@@ -146,8 +146,8 @@ class Group extends \ORM implements GroupInterface {
 					$checkPermission = substr($permission, 0, -1);
 
 					// We will make sure that the merged permission does not
-					// exactly match our permission, but starts wtih it.
-					if ($checkPermission != $groupPermission and Text::starts_with($groupPermission, $checkPermission) and $value == 1)
+					// exactly match our permission, but starts with it.
+					if ($checkPermission != $groupPermission and \Text::starts_with($groupPermission, $checkPermission) and $value == 1)
 					{
 						$matched = true;
 						break;
@@ -158,7 +158,7 @@ class Group extends \ORM implements GroupInterface {
 			// Now, let's check if the permission starts in a wildcard "*" symbol.
 			// If it does, we'll check through all the merged permissions to see
 			// if a permission exists which matches the wildcard.
-			elseif ((strlen($permission) > 1) and Text::starts_with($permission, '*'))
+			elseif ((strlen($permission) > 1) and \Text::starts_with($permission, '*'))
 			{
 				$matched = false;
 
@@ -168,8 +168,8 @@ class Group extends \ORM implements GroupInterface {
 					$checkPermission = substr($permission, 1);
 
 					// We will make sure that the merged permission does not
-					// exactly match our permission, but ends wtih it.
-					if ($checkPermission != $groupPermission and Text::ends_with($groupPermission, $checkPermission) and $value == 1)
+					// exactly match our permission, but ends with it.
+					if ($checkPermission != $groupPermission and \Text::ends_with($groupPermission, $checkPermission) and $value == 1)
 					{
 						$matched = true;
 						break;
@@ -184,7 +184,7 @@ class Group extends \ORM implements GroupInterface {
 				foreach ($groupPermissions as $groupPermission => $value)
 				{
 					// This time check if the groupPermission ends in wildcard "*" symbol.
-					if ((strlen($groupPermission) > 1) and Text::ends_with($groupPermission, '*'))
+					if ((strlen($groupPermission) > 1) and \Text::ends_with($groupPermission, '*'))
 					{
 						$matched = false;
 
@@ -192,8 +192,8 @@ class Group extends \ORM implements GroupInterface {
 						$checkGroupPermission = substr($groupPermission, 0, -1);
 
 						// We will make sure that the merged permission does not
-						// exactly match our permission, but starts wtih it.
-						if ($checkGroupPermission != $permission and Text::starts_with($permission, $checkGroupPermission) and $value == 1)
+						// exactly match our permission, but starts with it.
+						if ($checkGroupPermission != $permission and \Text::starts_with($permission, $checkGroupPermission) and $value == 1)
 						{
 							$matched = true;
 							break;

--- a/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Groups/Kohana/Provider.php
@@ -107,6 +107,11 @@ class Provider implements ProviderInterface {
 	 */
 	public function create(array $attributes)
 	{
+		if ( ! isset($credentials['permissions']) )
+		{
+			$credentials['permissions'] = array();
+		}
+
 		$group = $this->createModel();
 		$group->values($attributes, array('name', 'permissions'));
 		$group->save();

--- a/src/Cartalyst/Sentry/Users/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/Provider.php
@@ -293,6 +293,11 @@ class Provider implements ProviderInterface {
 	 */
 	public function create(array $credentials)
 	{
+		if ( ! isset($credentials['permissions']) )
+		{
+			$credentials['permissions'] = array();
+		}
+
 		$user = $this->createModel();
 		$user->values($credentials);
 		$user->save();

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -632,7 +632,7 @@ class User extends \ORM implements UserInterface {
 			// Now, let's check if the permission ends in a wildcard "*" symbol.
 			// If it does, we'll check through all the merged permissions to see
 			// if a permission exists which matches the wildcard.
-			if ((strlen($permission) > 1) and Text::ends_with($permission, '*'))
+			if ((strlen($permission) > 1) and \Text::ends_with($permission, '*'))
 			{
 				$matched = false;
 
@@ -642,8 +642,8 @@ class User extends \ORM implements UserInterface {
 					$checkPermission = substr($permission, 0, -1);
 
 					// We will make sure that the merged permission does not
-					// exactly match our permission, but starts wtih it.
-					if ($checkPermission != $mergedPermission and Text::starts_with($mergedPermission, $checkPermission) and $value == 1)
+					// exactly match our permission, but starts with it.
+					if ($checkPermission != $mergedPermission and \Text::starts_with($mergedPermission, $checkPermission) and $value == 1)
 					{
 						$matched = true;
 						break;
@@ -651,7 +651,7 @@ class User extends \ORM implements UserInterface {
 				}
 			}
 			
-			elseif ((strlen($permission) > 1) and Text::starts_with($permission, '*'))
+			elseif ((strlen($permission) > 1) and \Text::starts_with($permission, '*'))
 			{
 				$matched = false;
 
@@ -662,7 +662,7 @@ class User extends \ORM implements UserInterface {
 
 					// We will make sure that the merged permission does not
 					// exactly match our permission, but ends with it.
-					if ($checkPermission != $mergedPermission and Text::ends_with($mergedPermission, $checkPermission) and $value == 1)
+					if ($checkPermission != $mergedPermission and \Text::ends_with($mergedPermission, $checkPermission) and $value == 1)
 					{
 						$matched = true;
 						break;
@@ -677,7 +677,7 @@ class User extends \ORM implements UserInterface {
 				foreach ($mergedPermissions as $mergedPermission => $value)
 				{
 					// This time check if the mergedPermission ends in wildcard "*" symbol.
-					if ((strlen($mergedPermission) > 1) and Text::ends_with($mergedPermission, '*'))
+					if ((strlen($mergedPermission) > 1) and \Text::ends_with($mergedPermission, '*'))
 					{
 						$matched = false;
 
@@ -685,8 +685,8 @@ class User extends \ORM implements UserInterface {
 						$checkMergedPermission = substr($mergedPermission, 0, -1);
 
 						// We will make sure that the merged permission does not
-						// exactly match our permission, but starts wtih it.
-						if ($checkMergedPermission != $permission and Text::starts_with($permission, $checkMergedPermission) and $value == 1)
+						// exactly match our permission, but starts with it.
+						if ($checkMergedPermission != $permission and \Text::starts_with($permission, $checkMergedPermission) and $value == 1)
 						{
 							$matched = true;
 							break;


### PR DESCRIPTION
- call to Text now happens from the root namespace
- on create user/groups that don't have permissions set get an empty
  array
- spelling mistakes
