### PR TITLE
Fix toArray method calls in Throttle.

### DIFF
--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
@@ -359,11 +359,11 @@ class Throttle extends Model implements ThrottleInterface {
 
 		if (isset($result['suspended']))
 		{
-			$result['suspended'] = $this->getSuspended($result['suspended']);
+			$result['suspended'] = $this->getSuspendedAttribute($result['suspended']);
 		}
 		if (isset($result['banned']))
 		{
-			$result['banned'] = $this->getBanned($result['banned']);
+			$result['banned'] = $this->getBannedAttribute($result['banned']);
 		}
 		if (isset($result['last_attempt_at']) and $result['last_attempt_at'] instanceof DateTime)
 		{


### PR DESCRIPTION
getBanned() and getBanned() do not exists on Throttle, so they get passed to the magic call function of model, resulting in an error: `Call to undefined method Illuminate\Database\Query\Builder::getSuspended()`
This fixes both calls.
