### PR TITLE
Adds the ability to log in without activation

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -310,12 +310,13 @@ class Sentry {
 	 *
 	 * @param  \Cartalyst\Sentry\Users\UserInterface  $user
 	 * @param  bool  $remember
+	 * @param  bool  $requiresActivation
 	 * @return void
 	 * @throws \Cartalyst\Sentry\Users\UserNotActivatedException
 	 */
-	public function login(UserInterface $user, $remember = false)
+	public function login(UserInterface $user, $remember = false, $requiresActivation = true)
 	{
-		if ( ! $user->isActivated())
+		if ($requiresActivation && ! $user->isActivated())
 		{
 			$login = $user->getLogin();
 			throw new UserNotActivatedException("Cannot login user [$login] as they are not activated.");
@@ -343,10 +344,11 @@ class Sentry {
 	 * Alias for logging in and remembering.
 	 *
 	 * @param  \Cartalyst\Sentry\Users\UserInterface  $user
+	 * @param  bool  $requiresActivation
 	 */
-	public function loginAndRemember(UserInterface $user)
+	public function loginAndRemember(UserInterface $user, $requiresActivation = true)
 	{
-		$this->login($user, true);
+		$this->login($user, true, $requiresActivation);
 	}
 
 	/**


### PR DESCRIPTION
The app i'm developing requires the ability to log in without activation. (The app will then bug the user constantly about their account not being activated.)

There's an argument for moving this into the config file, making it affect all calls to Sentry::login(). But as the login method is not called much, it may be good to keep the option as a param, so it can be altered on a case-by-case basis.
