### PR TITLE
Update 2012_12_06_225988_migration_cartalyst_sentry_install_throttle.php

### DIFF
--- a/src/migrations/2012_12_06_225988_migration_cartalyst_sentry_install_throttle.php
+++ b/src/migrations/2012_12_06_225988_migration_cartalyst_sentry_install_throttle.php
@@ -44,7 +44,7 @@ class MigrationCartalystSentryInstallThrottle extends Migration {
 			// We'll need to ensure that MySQL uses the InnoDB engine to
 			// support the indexes, other engines aren't affected.
 			$table->engine = 'InnoDB';
-			$table->unique('user_id');
+			$table->index('user_id');
 		});
 	}
 


### PR DESCRIPTION
This fixes an issue in which you could potentially see when login in from different IP's.

1062 Duplicate entry '1' for key 'throttle_user_id_unique' (SQL: insert into `throttle` (`user_id`, `ip_address`) values (?, ?)) (Bindings: array ( 0 => '1', 1 => 'xxx.xx.xx.xx', ))

It also matches to meet the schema, which is not unique in:
sentry/schema/mysql.sql
