### PR TITLE
Use config-set models for user/group relationships.

### DIFF
--- a/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
+++ b/src/Cartalyst/Sentry/Groups/Eloquent/Group.php
@@ -51,6 +51,20 @@ class Group extends Model implements GroupInterface {
 	protected $allowedPermissionsValues = array(0, 1);
 
 	/**
+	 * The Eloquent user model.
+	 *
+	 * @var string
+	 */
+	protected static $userModel = 'Cartalyst\Sentry\Users\Eloquent\User';
+
+	/**
+	 * The user groups pivot table name.
+	 *
+	 * @var string
+	 */
+	protected static $userGroupsPivot = 'users_groups';
+
+	/**
 	 * Returns the group's ID.
 	 *
 	 * @return mixed
@@ -223,7 +237,29 @@ class Group extends Model implements GroupInterface {
 	 */
 	public function users()
 	{
-		return $this->belongsToMany('Cartalyst\Sentry\Users\Eloquent\User', 'users_groups');
+		return $this->belongsToMany(static::$userModel, static::$userGroupsPivot);
+	}
+
+	/**
+	 * Set the Eloquent model to use for user relationships.
+	 *
+	 * @param  string  $model
+	 * @return void
+	 */
+	public static function setUserModel($model)
+	{
+		static::$userModel = $model;
+	}
+
+	/**
+	 * Set the user groups pivot table name.
+	 *
+	 * @param  string  $tableName
+	 * @return void
+	 */
+	public static function setUserGroupsPivot($tableName)
+	{
+		static::$userGroupsPivot = $tableName;
 	}
 
 	/**

--- a/src/Cartalyst/Sentry/SentryServiceProvider.php
+++ b/src/Cartalyst/Sentry/SentryServiceProvider.php
@@ -112,7 +112,7 @@ class SentryServiceProvider extends ServiceProvider {
 			$model = $app['config']['cartalyst/sentry::users.model'];
 
 			// We will never be accessing a user in Sentry without accessing
-			// the user provider first. So, we can lazily setup our user
+			// the user provider first. So, we can lazily set up our user
 			// model's login attribute here. If you are manually using the
 			// attribute outside of Sentry, you will need to ensure you are
 			// overriding at runtime.
@@ -123,6 +123,28 @@ class SentryServiceProvider extends ServiceProvider {
 				forward_static_call_array(
 					array($model, 'setLoginAttributeName'),
 					array($loginAttribute)
+				);
+			}
+
+			// Define the Group model to use for relationships.
+			if (method_exists($model, 'setGroupModel'))
+			{
+				$groupModel = $app['config']['cartalyst/sentry::groups.model'];
+
+				forward_static_call_array(
+					array($model, 'setGroupModel'),
+					array($groupModel)
+				);
+			}
+
+			// Define the user group pivot table name to use for relationships.
+			if (method_exists($model, 'setUserGroupsPivot'))
+			{
+				$pivotTable = $app['config']['cartalyst/sentry::user_groups_pivot_table'];
+
+				forward_static_call_array(
+					array($model, 'setUserGroupsPivot'),
+					array($pivotTable)
 				);
 			}
 
@@ -140,6 +162,28 @@ class SentryServiceProvider extends ServiceProvider {
 		$this->app['sentry.group'] = $this->app->share(function($app)
 		{
 			$model = $app['config']['cartalyst/sentry::groups.model'];
+
+			// Define the User model to use for relationships.
+			if (method_exists($model, 'setUserModel'))
+			{
+				$userModel = $app['config']['cartalyst/sentry::users.model'];
+
+				forward_static_call_array(
+					array($model, 'setUserModel'),
+					array($userModel)
+				);
+			}
+
+			// Define the user group pivot table name to use for relationships.
+			if (method_exists($model, 'setUserGroupsPivot'))
+			{
+				$pivotTable = $app['config']['cartalyst/sentry::user_groups_pivot_table'];
+
+				forward_static_call_array(
+					array($model, 'setUserGroupsPivot'),
+					array($pivotTable)
+				);
+			}
 
 			return new GroupProvider($model);
 		});

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -111,6 +111,20 @@ class User extends Model implements UserInterface {
 	protected $mergedPermissions;
 
 	/**
+	 * The Eloquent group model.
+	 *
+	 * @var string
+	 */
+	protected static $groupModel = 'Cartalyst\Sentry\Groups\Eloquent\Group';
+
+	/**
+	 * The user groups pivot table name.
+	 *
+	 * @var string
+	 */
+	protected static $userGroupsPivot = 'users_groups';
+
+	/**
 	 * Returns the user's ID.
 	 *
 	 * @return  mixed
@@ -631,7 +645,7 @@ class User extends Model implements UserInterface {
 					}
 				}
 			}
-			
+
 			elseif ((strlen($permission) > 1) and starts_with($permission, '*'))
 			{
 				$matched = false;
@@ -735,7 +749,29 @@ class User extends Model implements UserInterface {
 	 */
 	public function groups()
 	{
-		return $this->belongsToMany('Cartalyst\Sentry\Groups\Eloquent\Group', 'users_groups');
+		return $this->belongsToMany(static::$groupModel, static::$userGroupsPivot);
+	}
+
+	/**
+	 * Set the Eloquent model to use for group relationships.
+	 *
+	 * @param  string  $model
+	 * @return void
+	 */
+	public static function setGroupModel($model)
+	{
+		static::$groupModel = $model;
+	}
+
+	/**
+	 * Set the user groups pivot table name.
+	 *
+	 * @param  string  $tableName
+	 * @return void
+	 */
+	public static function setUserGroupsPivot($tableName)
+	{
+		static::$userGroupsPivot = $tableName;
 	}
 
 	/**
@@ -774,7 +810,8 @@ class User extends Model implements UserInterface {
 	}
 
 	/**
-	 * Generate a random string. If your server has
+	 * Generate a random string.
+	 *
 	 * @return string
 	 */
 	public function getRandomString($length = 42)

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -127,15 +127,29 @@ return array(
 		| Login Attribute
 		|--------------------------------------------------------------------------
 		|
-		| If you're the "eloquent" driver and extending the base Eloquent model,
-		| we allow you to globally override the login attribute without even
-		| subclassing the model, simply by specifying the attribute below.
+		| If you're using the "eloquent" driver and extending the base Eloquent
+		| model, we allow you to globally override the login attribute without
+		| even subclassing the model, simply by specifying the attribute below.
 		|
 		*/
 
 		'login_attribute' => 'email',
 
 	),
+
+	/*
+	|--------------------------------------------------------------------------
+	| User Groups Pivot Table
+	|--------------------------------------------------------------------------
+	|
+	| When using the "eloquent" driver, you can specify the table name
+	| for the user groups pivot table.
+	|
+	| Default: users_groups
+	|
+	*/
+
+	'user_groups_pivot_table' => 'users_groups',
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
In addition/response to #263, this uses `SentryServiceProvider` to statically inject the User and Group models as defined in the Sentry config file and use them in the `users()` and `groups()` relationships respectively.

Also, while at it, I made the pivot table name configurable as well (I needed that personally, so since we're adding customizability, why stop at the model names?). Tested in my app and working well as best as I can tell.

I'm not entirely sure if I'm doing this in the most ideal / best practice way. I just tried to emulate what was already there for `setLoginAttributeName()`. I'd be happy to fix/update based on feedback. If unit tests are also desired with this, I can throw those in as well. :)

Cheers! :beer:
