### PR TITLE
Allow fallback algorithms that get upgraded for better security.

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/Provider.php
@@ -156,6 +156,17 @@ class Provider implements ProviderInterface {
 
 				throw new UserNotFoundException($message);
 			}
+			else if ($credential == $passwordName)
+			{
+				if (method_exists($this->hasher, 'needsRehashed') && 
+					$this->hasher->needsRehashed($user->{$credential}))
+				{
+					// The algorithm used to create the hash is outdated and insecure.
+					// Rehash the password and save.
+					$user->{$credential} = $value;
+					$user->save();
+				}
+			}
 		}
 
 		return $user;


### PR DESCRIPTION
Implements password rehashing according to https://wiki.php.net/rfc/password_hash. Also allows users with legacy systems to define their own hashing functions to verify passwords. Once an outdated password hash is verified the password is rehashed and saved back to the user table.

Example fallback usage:

``` php
// Fallback for sha1()
Cartalyst\Sentry\Hashing\NativeHasher::addFallback('sha1', function ($string, $hashedString) {
            return (sha1($string) == $hashedString);
});
// Poorly designed static salt:
Cartalyst\Sentry\Hashing\NativeHasher::addFallback('crypt', function ($string, $hashedString, $salt) {
            return (crypt($string, $salt) == $hashedString);
}, '12345');
// plain text?
Cartalyst\Sentry\Hashing\NativeHasher::addFallback('pt', function ($string, $hashedString) {
            return ($string === $hashedString);
});
```
