### PR TITLE
Adding a findByUserModel to the throttle provider

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -292,7 +292,7 @@ class Sentry {
 		if( $this->getThrottleProvider()->isEnabled())
 		{
 			// Check the throttle status
-			$throttle = $this->getThrottleProvider()->findByUserModel( $user );
+			$throttle = $this->getThrottleProvider()->findByUser( $user );
 
 			if( $throttle->isBanned() or $throttle->isSuspended())
 			{

--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Provider.php
@@ -71,7 +71,7 @@ class Provider implements ProviderInterface {
 	 * @param  string  $ipAddress
 	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserModel(UserInterface $user, $ipAddress = null)
+	public function findByUser(UserInterface $user, $ipAddress = null)
 	{
 		$model = $this->createModel();
 		$query = $model->where('user_id', '=', ($userId = $user->getId()));
@@ -103,7 +103,7 @@ class Provider implements ProviderInterface {
 	 */
 	public function findByUserId($id, $ipAddress = null)
 	{
-		return $this->findByUserModel($this->userProvider->findById($id),$ipAddress);
+		return $this->findByUser($this->userProvider->findById($id),$ipAddress);
 	}
 
 	/**
@@ -115,7 +115,7 @@ class Provider implements ProviderInterface {
 	 */
 	public function findByUserLogin($login, $ipAddress = null)
 	{
-		return $this->findByUserModel($this->userProvider->findByLogin($login),$ipAddress);
+		return $this->findByUser($this->userProvider->findByLogin($login),$ipAddress);
 	}
 
 	/**

--- a/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
+++ b/src/Cartalyst/Sentry/Throttling/Kohana/Provider.php
@@ -21,6 +21,7 @@
 use Cartalyst\Sentry\Throttling\ThrottleInterface;
 use Cartalyst\Sentry\Throttling\ProviderInterface;
 use Cartalyst\Sentry\Users\ProviderInterface as UserProviderInterface;
+use Cartalyst\Sentry\Users\UserInterface;
 
 class Provider implements ProviderInterface {
 
@@ -70,50 +71,10 @@ class Provider implements ProviderInterface {
 	 * @param  string  $ipAddress
 	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserId($id, $ipAddress = null)
+	public function findByUser(UserInterface $user, $ipAddress = null)
 	{
-		$user  = $this->userProvider->findById($id);
-		$user_id = $user->id;
-
 		$model = $this->createModel();
-		$query = $model->where('user_id', '=', $user_id);
-
-		if ($ipAddress)
-		{
-			$query->where('ip_address', '=', $ipAddress);
-		}
-
-		$throttle = $query->find();
-
-		if ( ! $throttle->loaded() )
-		{
-
-			$throttle = $this->createModel();
-			$values = array(
-				'user_id' => $user->id
-			);
-			if ($ipAddress) $values['ip_address'] = $ipAddress;
-			$throttle->values($values);
-			$throttle->save();
-		}
-
-		return $throttle;
-	}
-
-	/**
-	 * Finds a throttling interface by the given user login.
-	 *
-	 * @param  string  $login
-	 * @param  string  $ipAddress
-	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
-	 */
-	public function findByUserLogin($login, $ipAddress = null)
-	{
-		$user  = $this->userProvider->findByLogin($login);
-		$user_id = $user->id;
-
-		$model = $this->createModel();
-		$query = $model->where('user_id', '=', $user_id);
+		$query = $model->where('user_id', '=', ($user_id = $user->id));
 
 		if ($ipAddress)
 		{
@@ -131,6 +92,30 @@ class Provider implements ProviderInterface {
 		}
 
 		return $throttle;
+	}
+
+	/**
+	 * Finds a throttler by the given user ID.
+	 *
+	 * @param  mixed   $id
+	 * @param  string  $ipAddress
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
+	 */
+	public function findByUserId($id, $ipAddress = null)
+	{
+		return $this->findByUser($this->userProvider->findById($id),$ipAddress);
+	}
+
+	/**
+	 * Finds a throttling interface by the given user login.
+	 *
+	 * @param  string  $login
+	 * @param  string  $ipAddress
+	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
+	 */
+	public function findByUserLogin($login, $ipAddress = null)
+	{
+		return $this->findByUser($this->userProvider->findByLogin($login),$ipAddress);
 	}
 
 	/**

--- a/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
+++ b/src/Cartalyst/Sentry/Throttling/ProviderInterface.php
@@ -30,7 +30,7 @@ interface ProviderInterface {
 	 * @param  string  $ipAddress
 	 * @return \Cartalyst\Sentry\Throttling\ThrottleInterface
 	 */
-	public function findByUserModel(UserInterface $user, $ipAddress = null);
+	public function findByUser(UserInterface $user, $ipAddress = null);
 
 	/**
 	 * Finds a throttler by the given user ID.

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -324,7 +324,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 
 		$user->shouldReceive('isActivated')->once()->andReturn(true);
 
-		$this->throttleProvider->shouldReceive('findByUserModel')->once()->andReturn($throttle);
+		$this->throttleProvider->shouldReceive('findByUser')->once()->andReturn($throttle);
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
 
 		$this->sentry->setUser($user);
@@ -346,7 +346,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 
 		$user->shouldReceive('isActivated')->once()->andReturn(true);
 
-		$this->throttleProvider->shouldReceive('findByUserModel')->once()->andReturn($throttle);
+		$this->throttleProvider->shouldReceive('findByUser')->once()->andReturn($throttle);
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
 
 		$this->sentry->setSession($session);
@@ -369,7 +369,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 
 		$user->shouldReceive('isActivated')->once()->andReturn(true);
 
-		$this->throttleProvider->shouldReceive('findByUserModel')->once()->andReturn($throttle);
+		$this->throttleProvider->shouldReceive('findByUser')->once()->andReturn($throttle);
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
 
 		$this->sentry->setSession($session);
@@ -396,7 +396,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$throttle->shouldReceive('isBanned')->once()->andReturn(false);
 		$throttle->shouldReceive('isSuspended')->once()->andReturn(false);
 
-		$this->throttleProvider->shouldReceive('findByUserModel')->once()->andReturn($throttle);
+		$this->throttleProvider->shouldReceive('findByUser')->once()->andReturn($throttle);
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
 
 		$this->userProvider->shouldReceive('findById')->andReturn($user = m::mock('Cartalyst\Sentry\Users\UserInterface'));
@@ -417,7 +417,7 @@ class SentryTest extends PHPUnit_Framework_TestCase {
 		$throttle->shouldReceive('isSuspended')->once()->andReturn(false);
 
 		$this->userProvider->shouldReceive('findById')->andReturn($user = m::mock('Cartalyst\Sentry\Users\UserInterface'));
-		$this->throttleProvider->shouldReceive('findByUserModel')->once()->andReturn($throttle);
+		$this->throttleProvider->shouldReceive('findByUser')->once()->andReturn($throttle);
 		$this->throttleProvider->shouldReceive('isEnabled')->once()->andReturn(true);
 
 		$user->shouldReceive('checkPersistCode')->with('persist_code')->once()->andReturn(true);


### PR DESCRIPTION
When using Sentry::check() multiple times i noticed that it makes 2 queries for getting the user and the throttle.
The check() method already has a user model to give to the throttle provider.

So instead of just giving the id we give the whole model so we don't have to redo the query,

Also reduced the amount of double code to zero.

PS: my first pull request via git ever, so be nice :laughing: 
