### PR TITLE
Use jar for fetching illuminate cookies instead of request

### DIFF
--- a/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
+++ b/src/Cartalyst/Sentry/Cookies/IlluminateCookie.php
@@ -115,7 +115,7 @@ class IlluminateCookie implements CookieInterface {
 			return $queued[$key];
 		}
 
-		return $this->request->cookie($key);
+		return $this->jar->get($key);
 	}
 
 	/**


### PR DESCRIPTION
This will prevent fetching of encrypted values on cookies. This is specifically a fix for the "remember me" functionality not working.
