### PR TITLE
Require doctrine/dbal for Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
 	"require": {
 		"php": ">=5.3.3",
 		"illuminate/events": ">=4.0.9,<4.2",
-		"illuminate/support": ">=4.0.9,<4.2"
+		"illuminate/support": ">=4.0.9,<4.2",
+		"doctrine/dbal": "2.4.*"
 	},
 	"require-dev": {
 		"mockery/mockery": "0.7.2",


### PR DESCRIPTION
Uhm… [doctrine/dbal](https://github.com/doctrine/dbal) seems to be [no longer included in Laravel 4.1](https://github.com/laravel/framework/blob/master/composer.json#L91). This causes an exception being thrown when using `artisan migrate`, because [Sentry uses `$table->renameColumn()` in the "alter throttle" migration](https://github.com/cartalyst/sentry/blob/develop/src/migrations/2013_11_26_025024_migration_cartalyst_sentry_alter_throttle.php#L33):

``` php
$table->renameColumn('ip_address', 'ip');
```

Maybe let's require this library in the `composer.json`?
