### PR TITLE
Fixes Sentry::register method

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -158,7 +158,7 @@ class Sentry {
 	 */
 	public function register(array $credentials, $callback = null)
 	{
-		if ($callback !== null and ! $callback instanceof Closure and $callback !== true)
+		if ($callback !== null and ! $callback instanceof Closure and is_bool($callback))
 		{
 			throw new \InvalidArgumentException('You must provide a closure or true boolean.');
 		}


### PR DESCRIPTION
By definition Sentry::register accepts a closure or a boolean in second parameter, but if the second parameter is false, is throw a InvalidArgumentException.
