### PR TITLE
Logical Operator Fixes

### DIFF
--- a/src/Cartalyst/Sentry/Checkpoints/ThrottleCheckpoint.php
+++ b/src/Cartalyst/Sentry/Checkpoints/ThrottleCheckpoint.php
@@ -118,7 +118,7 @@ class ThrottleCheckpoint implements CheckpointInterface {
 		// leave the logged in user unaffected. Picture a famous person who's
 		// account is being locked as they're logged in, purely because
 		// others are trying to hack it.
-		if ($action === 'login' and isset($user))
+		if ($action === 'login' && isset($user))
 		{
 			$userDelay = $this->throttle->userDelay($user);
 

--- a/src/Cartalyst/Sentry/Laravel/SentryServiceProvider.php
+++ b/src/Cartalyst/Sentry/Laravel/SentryServiceProvider.php
@@ -103,7 +103,7 @@ class SentryServiceProvider extends ServiceProvider {
 			$model = $app['config']['cartalyst/sentry::users.model'];
 
 			$groups = $app['config']['cartalyst/sentry::groups.model'];
-			if (class_exists($groups) and method_exists($groups, 'setUsersModel'))
+			if (class_exists($groups) && method_exists($groups, 'setUsersModel'))
 			{
 				forward_static_call_array(array($groups, 'setUsersModel'), array($model));
 			}
@@ -127,7 +127,7 @@ class SentryServiceProvider extends ServiceProvider {
 			$model = $app['config']['cartalyst/sentry::groups.model'];
 
 			$users = $app['config']['cartalyst/sentry::users.model'];
-			if (class_exists($users) and method_exists($users, 'setGroupsModel'))
+			if (class_exists($users) && method_exists($users, 'setGroupsModel'))
 			{
 				forward_static_call_array(array($users, 'setGroupsModel'), array($model));
 			}
@@ -295,7 +295,7 @@ class SentryServiceProvider extends ServiceProvider {
 				$login = $request->getUser();
 				$password = $request->getPassword();
 
-				if ($login === null and $password === null)
+				if ($login === null && $password === null)
 				{
 					return;
 				}

--- a/src/Cartalyst/Sentry/Native/SentryBootstrapper.php
+++ b/src/Cartalyst/Sentry/Native/SentryBootstrapper.php
@@ -88,7 +88,7 @@ class SentryBootstrapper {
 		$model = $this->config['users']['model'];
 
 		$groups = $this->config['groups']['model'];
-		if (class_exists($groups) and method_exists($groups, 'setUsersModel'))
+		if (class_exists($groups) && method_exists($groups, 'setUsersModel'))
 		{
 			forward_static_call_array(array($groups, 'setUsersModel'), array($model));
 		}
@@ -106,7 +106,7 @@ class SentryBootstrapper {
 		$model = $this->config['groups']['model'];
 
 		$users = $this->config['users']['model'];
-		if (class_exists($users) and method_exists($users, 'setGroupsModel'))
+		if (class_exists($users) && method_exists($users, 'setGroupsModel'))
 		{
 			forward_static_call_array(array($users, 'setGroupsModel'), array($model));
 		}

--- a/src/Cartalyst/Sentry/Permissions/BasePermissions.php
+++ b/src/Cartalyst/Sentry/Permissions/BasePermissions.php
@@ -220,14 +220,14 @@ abstract class BasePermissions implements PermissionsInterface {
 	 */
 	protected function checkPermission(array $prepared, $permission)
 	{
-		if (array_key_exists($permission, $prepared) and $prepared[$permission] === true)
+		if (array_key_exists($permission, $prepared) && $prepared[$permission] === true)
 		{
 			return true;
 		}
 
 		foreach ($prepared as $key => $value)
 		{
-			if (str_is($permission, $key) and $value === true)
+			if (str_is($permission, $key) && $value === true)
 			{
 				return true;
 			}

--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -151,7 +151,7 @@ class Sentry {
 	 */
 	public function register(array $credentials, $callback = null)
 	{
-		if ($callback !== null and ! $callback instanceof Closure and ! is_bool($callback))
+		if ($callback !== null && ! $callback instanceof Closure && ! is_bool($callback))
 		{
 			throw new \InvalidArgumentException('You must provide a closure or a boolean.');
 		}
@@ -296,7 +296,7 @@ class Sentry {
 
 			$valid = $user !== null ? $this->users->validateCredentials($user, $credentials) : false;
 
-			if ($user === null or $valid === false)
+			if ($user === null || $valid === false)
 			{
 				$this->cycleCheckpoints('fail', $user, false);
 
@@ -608,7 +608,7 @@ class Sentry {
 		{
 			$response = $checkpoint->$method($user);
 
-			if ($response === false and $halt === true)
+			if ($response === false && $halt === true)
 			{
 				return false;
 			}
@@ -657,7 +657,7 @@ class Sentry {
 	 */
 	public function getUser($check = true)
 	{
-		if ($check === true and $this->user === null)
+		if ($check === true && $this->user === null)
 		{
 			$this->check();
 		}

--- a/src/Cartalyst/Sentry/Sessions/NativeSession.php
+++ b/src/Cartalyst/Sentry/Sessions/NativeSession.php
@@ -85,7 +85,7 @@ class NativeSession implements SessionInterface {
 	protected function startSession()
 	{
 		// Check that the session hasn't already been started
-		if (session_id() == '' and ! headers_sent())
+		if (session_id() == '' && ! headers_sent())
 		{
 			session_start();
 		}

--- a/src/Cartalyst/Sentry/Users/BaseUserRepository.php
+++ b/src/Cartalyst/Sentry/Users/BaseUserRepository.php
@@ -203,7 +203,7 @@ abstract class BaseUserRepository implements UserRepositoryInterface {
 			}
 		}
 
-		if ($password and strlen($password) < 6)
+		if ($password && strlen($password) < 6)
 		{
 			throw new \InvalidArgumentException('Your [password] must be at least 6 characters.');
 		}


### PR DESCRIPTION
Use `&&` rather than `and` and `||` rather than `or` to avoid some potential issues.
