### PR TITLE
Updates Composer require from 2.0.* to 2.1.*

### DIFF
--- a/docs/installation/laravel-4.md
+++ b/docs/installation/laravel-4.md
@@ -8,7 +8,7 @@ Open your `composer.json` file and add the following lines:
 
 	{
 		"require": {
-			"cartalyst/sentry": "2.0.*",
+			"cartalyst/sentry": "2.1.*",
 		},
 		"minimum-stability": "stable"
 	}


### PR DESCRIPTION
[Documentation Update]This reflects the current version of Sentry that should be used for projects.
