### PR TITLE
makes user_id field nullable in throttle table

### DIFF
--- a/src/migrations/2012_12_06_225988_migration_cartalyst_sentry_install_throttle.php
+++ b/src/migrations/2012_12_06_225988_migration_cartalyst_sentry_install_throttle.php
@@ -32,7 +32,7 @@ class MigrationCartalystSentryInstallThrottle extends Migration {
 		Schema::create('throttle', function($table)
 		{
 			$table->increments('id');
-			$table->integer('user_id')->unsigned();
+			$table->integer('user_id')->unsigned()->nullable();
 			$table->string('ip_address')->nullable();
 			$table->integer('attempts')->default(0);
 			$table->boolean('suspended')->default(0);


### PR DESCRIPTION
If a user attempts to sign in with an account that does not exists, the exception below is thrown, because Sentry attempts to update the throttle table with a null user_id. This makes the user_id field nullable.

```
Illuminate \ Database \ QueryException
SQLSTATE[HY000]: General error: 1364 Field 'user_id' doesn't have a default value (SQL: insert into `throttle` (`type`, `updated_at`, `created_at`) values (global, 2014-03-27 08:55:12, 2014-03-27 08:55:12))
```
