### PR TITLE
Updated documentation links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,10 +28,10 @@ It also provides additional features such as user groups and additional security
 
 Installation of Sentry is very easy. We've got a number of guides to get Sentry working with your favorite framework or on it's own:
 
-1. Install in [Laravel 4](http://docs.cartalyst.com/sentry-2/installation/laravel-4)
-2. Install in [FuelPHP 1](http://docs.cartalyst.com/sentry-2/installation/fuelphp-1)
-3. Install in [CodeIgniter 3](http://docs.cartalyst.com/sentry-2/installation/codeigniter-3)
-4. Use [natively (through composer)](http://docs.cartalyst.com/sentry-2/installation/composer)
+1. Install in [Laravel 4](https://cartalyst.com/manual/sentry/installation/laravel-4)
+2. Install in [FuelPHP 1](https://cartalyst.com/manual/sentry/installation/fuelphp-1)
+3. Install in [CodeIgniter 3](https://cartalyst.com/manual/sentry/installation/codeigniter-3)
+4. Use [natively (through composer)](https://cartalyst.com/manual/sentry/installation/composer)
 
 ### Upgrading
 


### PR DESCRIPTION
Installation links were being redirected to https://cartalyst.com/manual/sentry. Updated links to corresponding installation pages.
