### PR TITLE
[ELOQUENT] Use freshTimestamp instead of DateTime

### DIFF
--- a/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
+++ b/src/Cartalyst/Sentry/Throttling/Eloquent/Throttle.php
@@ -308,7 +308,7 @@ class Throttle extends Model implements ThrottleInterface {
 
 		$suspensionTime  = static::$suspensionTime;
 		$clearAttemptsAt = $lastAttempt->modify("+{$suspensionTime} minutes");
-		$now             = new DateTime;
+		$now             = $this->freshTimestamp();
 
 		if ($clearAttemptsAt <= $now)
 		{
@@ -334,7 +334,7 @@ class Throttle extends Model implements ThrottleInterface {
 
 		$suspensionTime = static::$suspensionTime;
 		$unsuspendAt    = $suspended->modify("+{$suspensionTime} minutes");
-		$now            = new DateTime;
+		$now            = $this->freshTimestamp();
 
 		if ($unsuspendAt <= $now)
 		{
@@ -462,7 +462,7 @@ class Throttle extends Model implements ThrottleInterface {
 
 		$suspensionTime  = static::$suspensionTime;
 		$clearAttemptsAt = $lastAttempt->modify("+{$suspensionTime} minutes");
-		$now             = new Datetime;
+		$now             = $this->freshTimestamp();
 
 		$timeLeft = $clearAttemptsAt->diff($now);
 

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -26,7 +26,6 @@ use Cartalyst\Sentry\Users\PasswordRequiredException;
 use Cartalyst\Sentry\Users\UserAlreadyActivatedException;
 use Cartalyst\Sentry\Users\UserExistsException;
 use Cartalyst\Sentry\Users\UserInterface;
-use DateTime;
 
 class User extends Model implements UserInterface {
 
@@ -398,7 +397,7 @@ class User extends Model implements UserInterface {
 		{
 			$this->activation_code = null;
 			$this->activated       = true;
-			$this->activated_at    = new DateTime;
+			$this->activated_at    = $this->freshTimestamp();
 			return $this->save();
 		}
 
@@ -738,7 +737,7 @@ class User extends Model implements UserInterface {
 	 */
 	public function recordLogin()
 	{
-		$this->last_login = new DateTime;
+		$this->last_login = $this->freshTimestamp();
 		$this->save();
 	}
 


### PR DESCRIPTION
Let's use `freshTimestamp()` instead
