### PR TITLE
When adding or removing groups on a user object, the merged permissions cache should be cleared.

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -493,6 +493,22 @@ class User extends Model implements UserInterface {
 		return $this->userGroups;
 	}
 
+    /**
+     * Clear the cached permissions attribute.
+     */
+    public function invalidateMergedPermissionsCache()
+    {
+		$this->mergedPermissions = null;
+    }
+
+    /**
+     * Clear the cached user groups attribute.
+     */
+    public function invalidateUserGroupsCache()
+    {
+		$this->userGroups = null;
+    }
+    
 	/**
 	 * Adds the user to the given group.
 	 *
@@ -504,7 +520,8 @@ class User extends Model implements UserInterface {
 		if ( ! $this->inGroup($group))
 		{
 			$this->groups()->attach($group);
-			$this->userGroups = null;
+			$this->invalidateUserGroupsCache();
+			$this->invalidateMergedPermissionsCache();
 		}
 
 		return true;
@@ -521,7 +538,8 @@ class User extends Model implements UserInterface {
 		if ($this->inGroup($group))
 		{
 			$this->groups()->detach($group);
-			$this->userGroups = null;
+			$this->invalidateUserGroupsCache();
+			$this->invalidateMergedPermissionsCache();
 		}
 
 		return true;

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -110,9 +110,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$relationship = m::mock('StdClass');
 		$relationship->shouldReceive('attach')->with($group)->once();
 
-		$user  = m::mock('Cartalyst\Sentry\Users\Eloquent\User[inGroup,groups]');
+		$user  = m::mock('Cartalyst\Sentry\Users\Eloquent\User[inGroup,groups,invalidateMergedPermissionsCache,invalidateUserGroupsCache]');
 		$user->shouldReceive('inGroup')->once()->andReturn(false);
 		$user->shouldReceive('groups')->once()->andReturn($relationship);
+		$user->shouldReceive('invalidateUserGroupsCache')->once();
+		$user->shouldReceive('invalidateMergedPermissionsCache')->once();
 
 		$this->assertTrue($user->addGroup($group));
 	}
@@ -124,9 +126,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$relationship = m::mock('StdClass');
 		$relationship->shouldReceive('detach')->with($group)->once();
 
-		$user  = m::mock('Cartalyst\Sentry\Users\Eloquent\User[inGroup,groups]');
+		$user  = m::mock('Cartalyst\Sentry\Users\Eloquent\User[inGroup,groups,invalidateMergedPermissionsCache,invalidateUserGroupsCache]');
 		$user->shouldReceive('inGroup')->once()->andReturn(true);
 		$user->shouldReceive('groups')->once()->andReturn($relationship);
+		$user->shouldReceive('invalidateUserGroupsCache')->once();
+		$user->shouldReceive('invalidateMergedPermissionsCache')->once();
 
 		$this->assertTrue($user->removeGroup($group));
 	}


### PR DESCRIPTION
In practice this is not usually a problem, as a user is usually mutated in the database and the permissions checked when a new request is made.

We ran into this problem when testing a custom permission system:

``` PHP
$user->addGroup($group);
$this->assertTrue(Access::hasControllerPermission('SomeController', 'group_authorized_action', array()));
$user->removeGroup($group);
// This assertion fails without the pull request's changesets:
$this->assertFalse(Access::hasControllerPermission('SomeController', 'group_authorized_action', array()));
```
