### PR TITLE
[Schema] throttle.user_id can be nullable

### DIFF
--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -132,7 +132,7 @@ DROP TABLE IF EXISTS `throttle`;
 CREATE TABLE `throttle` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `user_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NULL,
   `ip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',


### PR DESCRIPTION
For `throttle` table, `user_id` will only be filled for `user` type, so it can be nullable as `ip` column already is...
