### PR TITLE
Fix spelling mistakes and duplicate array key

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -139,14 +139,14 @@ return [
 	| Here, you may configure your site's throttling settings. There are three
 	| types of throttling.
 	|
-	| The first type is "global". Global throttling will monitor the overal
-	| failed login attemps across your site and can limit the affects of an
+	| The first type is "global". Global throttling will monitor the overall
+	| failed login attempts across your site and can limit the affects of an
 	| attempted DDoS attack.
 	|
 	| The second type is "ip". This allows you to throttle the failed login
-	| attemps (across any account) of a given IP address.
+	| attempts (across any account) of a given IP address.
 	|
-	| The third type is "user". This allows you to throttle the login attemps
+	| The third type is "user". This allows you to throttle the login attempts
 	| on an individual user account.
 	|
 	| Each type of throttling has the same options. The first is the interval.
@@ -159,16 +159,16 @@ return [
 	| the next attempt can occur.
 	|
 	| The second way is by providing an integer. If the number of failed login
-	| attempts outweight the thresholds integer, that throttle is locked until
+	| attempts outweigh the thresholds integer, that throttle is locked until
 	| there are no more failed login attempts within the specified interval.
 	|
 	| On this premise, we encourage you to use array thresholds for global
-	| throttling (and perhapse IP throttling as well), so as to not lock your
+	| throttling (and perhaps IP throttling as well), so as to not lock your
 	| whole site out for minutes on end because it's being DDoS'd. However,
 	| for user throttling, locking a single account out because somebody is
 	| attempting to breach it could be an appropriate response.
 	|
-	| You may use any type of throtttling for any scenario, and the specific
+	| You may use any type of throttling for any scenario, and the specific
 	| configurations are designed to be customized as your site grows.
 	|
 	*/
@@ -185,7 +185,7 @@ return [
 				10 => 1,
 				20 => 2,
 				30 => 4,
-				50 => 8,
+				40 => 8,
 				50 => 16,
 				60 => 12
 			],


### PR DESCRIPTION
Fixed a few spelling mistakes as well as a duplicate array key in the global throttling thresholds array.
