### PR TITLE
modify getPassword so it respect getPasswordName

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -170,7 +170,7 @@ class User extends Model implements UserInterface {
 	 */
 	public function getPassword()
 	{
-		return $this->password;
+		return $this->{$this->getPasswordName()};
 	}
 
 	/**


### PR DESCRIPTION
when trying to extend this model, and using custom password field, it not respect overrided getPasswordName() 

e.g. I want to change password field to other field, and use model below as user model

``` php
class ProviderCredential extends Cartalyst\Sentry\Users\Eloquent\User {

    public function getPasswordName()
    {
        return 'OtherThanDefaultPasswordField';
    }
}
```
