### PR TITLE
Change 'Assign' to 'Remove' in 'Delete a Group' section.

### DIFF
--- a/docs/users/update.md
+++ b/docs/users/update.md
@@ -104,7 +104,7 @@ will be thrown.
 		// Find the group using the group id
 		$adminGroup = Sentry::findGroupById(1);
 
-		// Remove group from the user.
+		// Remove group from the user
 		if ($user->removeGroup($adminGroup))
 		{
 			// Group removed successfully


### PR DESCRIPTION
The comment in the "Delete a Group" section should be "Remove group from the user" instead "Assign the group to the user" when the function $user->removeGroup() is called.
