### PR TITLE
Compatibility with watson/validating package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
 	"suggest": {
 		"illuminate/database": "Default sentry user, group and throttling implementations.",
 		"ircmaxell/password-compat": "Default hashing uses PHP 5.5 password_* functions, with forward-compatible support.",
-		"happydemon/txt": "Required Text helpers when using the Kohana implementation"
+		"happydemon/txt": "Required Text helpers when using the Kohana implementation",
+		"watson/validating": "Helpful package when using Laravel implementation"
 	},
 	"autoload": {
 		"classmap": [

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -312,7 +312,9 @@ class User extends Model implements UserInterface {
 	 */
 	public function save(array $options = array())
 	{
-		$this->validate();
+		if (!method_exists($this, 'bootValidatingTrait')) {
+			$this->validate();
+		}
 
 		return parent::save($options);
 	}


### PR DESCRIPTION
When model is implementing ValidatingTrait from [watson/validating](https://github.com/dwightwatson/validating) package, Sentry isn't running `validate` method and thanks to this isn't throwing exceptions, but is returning true/false depending on whether the model is correct.

Now we can use something like this (Laravel):

``` php
$user = Sentry::register($credentials);

if (!$user->save()) {
    return Redirect::back()->withErrors($user->getErrors()); // fail
}
return Redirect::home(); //success
```

(Sorry for my bad english)
