### PR TITLE
Check currently logged-in user's group by group name

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -544,10 +544,12 @@ class Sentry {
 	*/
 	public function checkGroup($group_name)
 	{
-	        if (Sentry::check()) {
-	            $user_id = Sentry::getUser()->id;
-                    $get_user = Sentry::findUserByID($user_id);
-                    $group = Sentry::findGroupByName($group_name);
+	    if (Sentry::check())
+	    {
+	        $user_id = Sentry::getUser()->id;
+                $get_user = Sentry::findUserByID($user_id);
+                $group = Sentry::findGroupByName($group_name);
+                
                 if ($get_user->inGroup($group)) {         
                     return true;
                 }


### PR DESCRIPTION
It is useful when we want to change content in template files depending on the currently logged-in user's group

Like showing "Admin Dashboard" link in menu bar if the logged-in user is in group named "Administrator" 
