### PR TITLE
Request instance fix if request binding does not exist in the application

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
 	"require-dev": {
 		"mockery/mockery": "0.7.2",
 
-		"illuminate/cookie": ">=4.0.9,<4.2",
-		"illuminate/database": ">=4.0.9,<4.2",
-		"illuminate/http": ">=4.0.9,<4.2",
-		"illuminate/session": ">=4.0.9,<4.2",
+		"illuminate/cookie": "~5.0",
+		"illuminate/database": "~5.0",
+		"illuminate/http": "~5.0",
+		"illuminate/session": "~5.0",
 		"ircmaxell/password-compat": "1.0.*"
 	},
 	"suggest": {

--- a/src/Cartalyst/Sentry/SentryServiceProvider.php
+++ b/src/Cartalyst/Sentry/SentryServiceProvider.php
@@ -33,22 +33,13 @@ use Illuminate\Support\ServiceProvider;
 class SentryServiceProvider extends ServiceProvider {
 
 	/**
-	 * Boot the service provider.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		$this->package('cartalyst/sentry', 'cartalyst/sentry');
-	}
-
-	/**
 	 * Register the service provider.
 	 *
 	 * @return void
 	 */
 	public function register()
 	{
+		$this->prepareResources();
 		$this->registerHasher();
 		$this->registerUserProvider();
 		$this->registerGroupProvider();
@@ -56,6 +47,24 @@ class SentryServiceProvider extends ServiceProvider {
 		$this->registerSession();
 		$this->registerCookie();
 		$this->registerSentry();
+	}
+
+	/**
+	 * Prepare the package resources.
+	 *
+	 * @return void
+	 */
+	protected function prepareResources()
+	{
+		$config     = realpath(__DIR__.'/../../config/config.php');
+		$migrations = realpath(__DIR__.'/../../migrations');
+
+		$this->mergeConfigFrom($config, 'cartalyst.sentry');
+
+		$this->publishes([
+			$config     => config_path('cartalyst.sentry.php'),
+			$migrations => $this->app->databasePath().'/migrations',
+		]);
 	}
 
 	/**
@@ -67,7 +76,7 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.hasher'] = $this->app->share(function($app)
 		{
-			$hasher = $app['config']['cartalyst/sentry::hasher'];
+			$hasher = $app['config']->get('cartalyst.sentry.hasher');
 
 			switch ($hasher)
 			{
@@ -101,7 +110,9 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.user'] = $this->app->share(function($app)
 		{
-			$model = $app['config']['cartalyst/sentry::users.model'];
+			$config = $app['config']->get('cartalyst.sentry');
+
+			$model = array_get($config, 'users.model');
 
 			// We will never be accessing a user in Sentry without accessing
 			// the user provider first. So, we can lazily set up our user
@@ -110,7 +121,7 @@ class SentryServiceProvider extends ServiceProvider {
 			// overriding at runtime.
 			if (method_exists($model, 'setLoginAttributeName'))
 			{
-				$loginAttribute = $app['config']['cartalyst/sentry::users.login_attribute'];
+				$loginAttribute = array_get($config, 'users.login_attribute');
 
 				forward_static_call_array(
 					array($model, 'setLoginAttributeName'),
@@ -121,7 +132,7 @@ class SentryServiceProvider extends ServiceProvider {
 			// Define the Group model to use for relationships.
 			if (method_exists($model, 'setGroupModel'))
 			{
-				$groupModel = $app['config']['cartalyst/sentry::groups.model'];
+				$groupModel = array_get($config, 'groups.model');
 
 				forward_static_call_array(
 					array($model, 'setGroupModel'),
@@ -132,7 +143,7 @@ class SentryServiceProvider extends ServiceProvider {
 			// Define the user group pivot table name to use for relationships.
 			if (method_exists($model, 'setUserGroupsPivot'))
 			{
-				$pivotTable = $app['config']['cartalyst/sentry::user_groups_pivot_table'];
+				$pivotTable = array_get($config, 'user_groups_pivot_table');
 
 				forward_static_call_array(
 					array($model, 'setUserGroupsPivot'),
@@ -153,12 +164,14 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.group'] = $this->app->share(function($app)
 		{
-			$model = $app['config']['cartalyst/sentry::groups.model'];
+			$config = $app['config']->get('cartalyst.sentry');
+
+			$model = array_get($config, 'groups.model');
 
 			// Define the User model to use for relationships.
 			if (method_exists($model, 'setUserModel'))
 			{
-				$userModel = $app['config']['cartalyst/sentry::users.model'];
+				$userModel = array_get($config, 'users.model');
 
 				forward_static_call_array(
 					array($model, 'setUserModel'),
@@ -169,7 +182,7 @@ class SentryServiceProvider extends ServiceProvider {
 			// Define the user group pivot table name to use for relationships.
 			if (method_exists($model, 'setUserGroupsPivot'))
 			{
-				$pivotTable = $app['config']['cartalyst/sentry::user_groups_pivot_table'];
+				$pivotTable = array_get($config, 'user_groups_pivot_table');
 
 				forward_static_call_array(
 					array($model, 'setUserGroupsPivot'),
@@ -190,18 +203,20 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.throttle'] = $this->app->share(function($app)
 		{
-			$model = $app['config']['cartalyst/sentry::throttling.model'];
+			$config = $app['config']->get('cartalyst.sentry');
+
+			$model = array_get($config, 'throttling.model');
 
 			$throttleProvider = new ThrottleProvider($app['sentry.user'], $model);
 
-			if ($app['config']['cartalyst/sentry::throttling.enabled'] === false)
+			if (array_get($config, 'throttling.enabled') === false)
 			{
 				$throttleProvider->disable();
 			}
 
 			if (method_exists($model, 'setAttemptLimit'))
 			{
-				$attemptLimit = $app['config']['cartalyst/sentry::throttling.attempt_limit'];
+				$attemptLimit = array_get($config, 'throttling.attempt_limit');
 
 				forward_static_call_array(
 					array($model, 'setAttemptLimit'),
@@ -210,18 +225,18 @@ class SentryServiceProvider extends ServiceProvider {
 			}
 			if (method_exists($model, 'setSuspensionTime'))
 			{
-				$suspensionTime = $app['config']['cartalyst/sentry::throttling.suspension_time'];
+				$suspensionTime = array_get($config, 'throttling.suspension_time');
 
 				forward_static_call_array(
 					array($model, 'setSuspensionTime'),
 					array($suspensionTime)
 				);
 			}
-			
+
 			// Define the User model to use for relationships.
 			if (method_exists($model, 'setUserModel'))
 			{
-				$userModel = $app['config']['cartalyst/sentry::users.model'];
+				$userModel = array_get($config, 'users.model');
 
 				forward_static_call_array(
 					array($model, 'setUserModel'),
@@ -242,7 +257,7 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.session'] = $this->app->share(function($app)
 		{
-			$key = $app['config']['cartalyst/sentry::cookie.key'];
+			$key = $app['config']->get('cartalyst.sentry.cookie.key');
 
 			return new IlluminateSession($app['session.store'], $key);
 		});
@@ -257,7 +272,7 @@ class SentryServiceProvider extends ServiceProvider {
 	{
 		$this->app['sentry.cookie'] = $this->app->share(function($app)
 		{
-			$key = $app['config']['cartalyst/sentry::cookie.key'];
+			$key = $app['config']->get('cartalyst.sentry.cookie.key');
 
 			/**
 			 * We'll default to using the 'request' strategy, but switch to

--- a/tests/EloquentThrottleTest.php
+++ b/tests/EloquentThrottleTest.php
@@ -250,9 +250,9 @@ class EloquentThrottleTest extends PHPUnit_Framework_TestCase {
 	protected function addMockConnection($model)
 	{
 		$model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-		$resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
-		$model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-		$model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+		$resolver->shouldReceive('connection')->andReturn($connection = m::mock('callable'));
+		$connection->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+		$connection->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
 	}
 
 }

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -650,9 +650,9 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 	protected function addMockConnection($model)
 	{
 		$model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-		$resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection'));
-		$model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-		$model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
+		$resolver->shouldReceive('connection')->andReturn($connection = m::mock('callable'));
+		$connection->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+		$connection->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
 	}
 
 }


### PR DESCRIPTION
In testing environment request instance does not exist, Sentry fails, so we create a new request instance if app does not have a matching binding.