### PR TITLE
Null reset codes are not allowed

### DIFF
--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -438,8 +438,8 @@ class User extends Model implements UserInterface {
 	 */
 	public function checkResetPasswordCode($resetCode)
 	{
-		if (empty($resetCode)) {
-			throw new \RuntimeException('Something is wrong with the reset code.');
+		if ( ! $resetCode) {
+			return false;
 		}
 
 		return ($this->reset_password_code == $resetCode);

--- a/src/Cartalyst/Sentry/Users/Eloquent/User.php
+++ b/src/Cartalyst/Sentry/Users/Eloquent/User.php
@@ -438,6 +438,10 @@ class User extends Model implements UserInterface {
 	 */
 	public function checkResetPasswordCode($resetCode)
 	{
+		if (empty($resetCode)) {
+			throw new \RuntimeException('Something is wrong with the reset code.');
+		}
+
 		return ($this->reset_password_code == $resetCode);
 	}
 
@@ -492,22 +496,22 @@ class User extends Model implements UserInterface {
 		return $this->userGroups;
 	}
 
-    /**
-     * Clear the cached permissions attribute.
-     */
-    public function invalidateMergedPermissionsCache()
-    {
+	/**
+	 * Clear the cached permissions attribute.
+	 */
+	public function invalidateMergedPermissionsCache()
+	{
 		$this->mergedPermissions = null;
-    }
+	}
 
-    /**
-     * Clear the cached user groups attribute.
-     */
-    public function invalidateUserGroupsCache()
-    {
+	/**
+	 * Clear the cached user groups attribute.
+	 */
+	public function invalidateUserGroupsCache()
+	{
 		$this->userGroups = null;
-    }
-    
+	}
+
 	/**
 	 * Adds the user to the given group.
 	 *

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -441,6 +441,10 @@ class User extends \ORM implements UserInterface {
 	 */
 	public function checkResetPasswordCode($resetCode)
 	{
+		if (empty($resetCode)) {
+			throw new \RuntimeException('Something is wrong with the reset code.');
+		}
+
 		return ($this->reset_password_code == $resetCode);
 	}
 

--- a/src/Cartalyst/Sentry/Users/Kohana/User.php
+++ b/src/Cartalyst/Sentry/Users/Kohana/User.php
@@ -441,8 +441,8 @@ class User extends \ORM implements UserInterface {
 	 */
 	public function checkResetPasswordCode($resetCode)
 	{
-		if (empty($resetCode)) {
-			throw new \RuntimeException('Something is wrong with the reset code.');
+		if ( ! $resetCode) {
+			return false;
 		}
 
 		return ($this->reset_password_code == $resetCode);

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -542,15 +542,12 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($user->checkPassword('password'));
 	}
 
-	/**
-	 * @expectedException RuntimeException
-	 */
 	public function testResetPasswordCodeCannotBeNull()
 	{
 		User::setHasher($hasher = m::mock('Cartalyst\Sentry\Hashing\HasherInterface'));
 		$user = new User;
 
-		$user->checkResetPasswordCode(null);
+		$this->assertFalse($user->checkResetPasswordCode(null));
 	}
 
 	public function testCheckingResetPasswordCode()

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -542,6 +542,17 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($user->checkPassword('password'));
 	}
 
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testResetPasswordCodeCannotBeNull()
+	{
+		User::setHasher($hasher = m::mock('Cartalyst\Sentry\Hashing\HasherInterface'));
+		$user = new User;
+
+		$user->checkResetPasswordCode(null);
+	}
+
 	public function testCheckingResetPasswordCode()
 	{
 		User::setHasher($hasher = m::mock('Cartalyst\Sentry\Hashing\HasherInterface'));


### PR DESCRIPTION
The current schema for Eloquent-based users (maybe others as well, unsure) has  `reset_password_code` is `NULL` by default. The check for correct `$resetCode` simply does an equality comparison and returns true if there is a loose match.

If an attacker is able to provide a null reset code to the package, there are no guards against arbitrary anonymous password resets. In many cases, submitting a url-encoded null byte value (`%00`) will match what's in the database, passing the check and allowing the attacker to set the password to what they wish. Because implementors have reasonable control over the actual field names in their reset forms and processors, there might be some measure of "security through obscurity", but I feel like this is something that the package should cover anyway. Criticality of this is subjective, as a successful attack would need to reset a password and then properly derive the user identity -> email/username. If they have this, they likely have already owned the site. I feel this boils down to a denial of service, otherwise.

I know Sentry is deprecated, but with 1600+ stars and still a good chunk of folks using (https://packagist.org/packages/cartalyst/sentry/stats), I think it's reasonable to mitigate this in some way. My current applications mitigation is to simply disallow "empty" reset codes.
