### PR TITLE
Update Sentry.php

### DIFF
--- a/src/Cartalyst/Sentry/Sentry.php
+++ b/src/Cartalyst/Sentry/Sentry.php
@@ -292,7 +292,7 @@ class Sentry {
 		if( $this->getThrottleProvider()->isEnabled())
 		{
 			// Check the throttle status
-			$throttle = $this->getThrottleProvider()->findByUser( $user );
+			$throttle = $this->getThrottleProvider()->findByUser( $user , $this->ipAddress );
 
 			if( $throttle->isBanned() or $throttle->isSuspended())
 			{


### PR DESCRIPTION
Add IP address to the throttle check while logging in. This is now inline with the `Sentry::authenticate()` method and prevents account being marked as suspended or banned even when successfully logging in from another IP.